### PR TITLE
youngseok, fix: 문자+고객 관련 QA 해결 PR #53 #51 #50

### DIFF
--- a/src/components/customers/CustomerDetailModal.tsx
+++ b/src/components/customers/CustomerDetailModal.tsx
@@ -98,9 +98,10 @@ const CustomerDetailModal = ({ isOpen, onClose, customer, onUpdate }: CustomerDe
             </div>
 
             <div>
-              <h4 className="text-sm font-medium text-gray-500">연령대</h4>
+              <h4 className="text-sm font-medium text-gray-500">연령대 / 성별</h4>
               <p className="mt-1">
-                {customer.ageGroup}대 / {customer.gender === 'M' ? '남성' : '여성'}
+                {customer.ageGroup ? `${customer.ageGroup}대` : '선택 안 함'} /{' '}
+                {customer.gender === 'M' ? '남성' : customer.gender === 'F' ? '여성' : '선택 안 함'}
               </p>
             </div>
 

--- a/src/components/customers/CustomerForm.tsx
+++ b/src/components/customers/CustomerForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-// import { useState } from 'react';
+import { useEffect } from 'react';
 import { useForm, Controller } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
@@ -9,10 +9,20 @@ import Input from '../../components/ui/Input';
 import Button from '../../components/ui/Button';
 import Select from '../../components/ui/Select';
 import Textarea from '../../components/ui/Textarea';
-import type { Customer, CreateCustomerReqDto } from '../../types/customer';
+import type { CreateCustomerReqDto } from '../../types/customer';
 
 // Select 박스 옵션 생성
 const ageOptions = Array.from({ length: 10 }, (_, i) => (i + 1) * 10); // [10, 20, ..., 100]
+interface Option {
+  value: string;
+  label: string;
+}
+
+const genderOptions: Option[] = [
+  { value: '', label: '선택 안 함' },
+  { value: 'M', label: '남성' },
+  { value: 'F', label: '여성' },
+];
 
 // 유효성 검사 스키마
 const customerSchema = z.object({
@@ -25,18 +35,19 @@ const customerSchema = z.object({
     .string()
     .regex(/^\d{2,3}-\d{3,4}-\d{4}$/, '유효한 전화번호 형식을 입력해주세요. (예: 010-1234-5678)'),
   memo: z.preprocess((val) => (val === '' ? null : val), z.string().nullable()).optional(),
-  ageGroup: z.preprocess((val) => {
-    if (val === '') return undefined;
-    const num = Number(val);
-    return isNaN(num) ? undefined : num;
-  }, z.number().min(10).max(100).optional()),
+  ageGroup: z
+    .union([
+      z.number().min(10).max(100), // 숫자 범위 검증
+      z.null(), // null 값 허용
+    ])
+    .optional(),
   gender: z.preprocess((val) => (val === '' ? undefined : val), z.enum(['M', 'F']).optional()),
 });
 
 type CustomerFormData = z.infer<typeof customerSchema>;
 
 interface CustomerFormProps {
-  initialData?: Partial<Customer>;
+  initialData?: CreateCustomerReqDto;
   onSubmit: (data: CreateCustomerReqDto) => void;
   onCancel: () => void;
 }
@@ -45,6 +56,7 @@ const CustomerForm = ({ initialData, onSubmit, onCancel }: CustomerFormProps) =>
   const {
     control,
     handleSubmit,
+    reset,
     formState: { errors, isSubmitting },
   } = useForm<CustomerFormData>({
     resolver: zodResolver(customerSchema),
@@ -55,10 +67,22 @@ const CustomerForm = ({ initialData, onSubmit, onCancel }: CustomerFormProps) =>
       contact: initialData?.contact || '',
       memo: initialData?.memo,
       // 초기값이 없으면 undefined로 설정 (중요: null이 아님)
-      ageGroup: initialData?.ageGroup,
-      gender: initialData?.gender,
+      ageGroup: initialData?.ageGroup || undefined, // null 대신 undefined 사용
+      gender: initialData?.gender || undefined, // 빈 문자열 처리
     },
   });
+
+  // initialData 변경 시 폼 상태 리셋
+  useEffect(() => {
+    reset({
+      name: initialData?.name || '',
+      email: initialData?.email || '',
+      contact: initialData?.contact || '',
+      memo: initialData?.memo,
+      ageGroup: initialData?.ageGroup || undefined,
+      gender: initialData?.gender || undefined,
+    });
+  }, [initialData, reset]);
 
   // 폼 제출 처리
   const onFormSubmit = (data: CustomerFormData) => {
@@ -81,7 +105,6 @@ const CustomerForm = ({ initialData, onSubmit, onCancel }: CustomerFormProps) =>
     if (data.memo) {
       customerData.memo = data.memo;
     }
-
     onSubmit(customerData);
   };
 
@@ -145,16 +168,20 @@ const CustomerForm = ({ initialData, onSubmit, onCancel }: CustomerFormProps) =>
               control={control}
               render={({ field }) => (
                 <Select
-                  {...field}
+                  name={field.name}
+                  onBlur={field.onBlur}
+                  ref={field.ref}
+                  value={field.value === null ? '' : field.value?.toString()} // null 처리 및 문자열 변환
                   label="연령대"
                   options={[
                     { value: '', label: '선택 안 함' },
                     ...ageOptions.map((age) => ({
-                      value: age.toString(), // 문자열로 변환
+                      value: age.toString(),
                       label: `${age}`,
                     })),
                   ]}
                   error={errors.ageGroup?.message}
+                  onChange={(value) => field.onChange(value === '' ? null : Number(value))}
                 />
               )}
             />
@@ -164,12 +191,9 @@ const CustomerForm = ({ initialData, onSubmit, onCancel }: CustomerFormProps) =>
               render={({ field }) => (
                 <Select
                   {...field}
+                  value={field.value ?? ''} // 단순 값만 전달
                   label="성별"
-                  options={[
-                    { value: '', label: '선택 안 함' },
-                    { value: 'M', label: '남성' },
-                    { value: 'F', label: '여성' },
-                  ]}
+                  options={genderOptions}
                   error={errors.gender?.message}
                 />
               )}

--- a/src/components/layout/DashboardLayout.tsx
+++ b/src/components/layout/DashboardLayout.tsx
@@ -83,7 +83,7 @@ const DashboardLayout: React.FC<{ children: React.ReactNode }> = ({ children }) 
                 {menuItems.map((item) => (
                   <div
                     key={item.name}
-                    className="relative"
+                    className="relative group"
                     onMouseEnter={() => setHoveredItem(item.name)}
                     onMouseLeave={() => setHoveredItem(null)}
                   >
@@ -103,8 +103,12 @@ const DashboardLayout: React.FC<{ children: React.ReactNode }> = ({ children }) 
                     </NavLink>
 
                     {/* Dropdown menu for items with subitems */}
-                    {item.subItems && hoveredItem === item.name && (
-                      <div className="absolute z-10 left-0 mt-1 w-48 bg-white rounded-md shadow-lg py-1 ring-1 ring-black ring-opacity-5">
+                    {item.subItems && (
+                      <div
+                        className={`absolute z-10 left-0 mt-1 w-48 bg-white rounded-md shadow-lg py-1 ring-1 ring-black ring-opacity-5 transition-opacity duration-150 ${
+                          hoveredItem === item.name ? 'opacity-100 visible' : 'opacity-0 invisible'
+                        }`}
+                      >
                         {item.subItems.map((subItem) => (
                           <NavLink
                             key={subItem.name}

--- a/src/pages/customers/customer.tsx
+++ b/src/pages/customers/customer.tsx
@@ -71,7 +71,7 @@ const CustomersPage = () => {
         setCustomers(response.data.content);
         setPagination(response.data.pagination);
       } else {
-        showToast('API 응답에 데이터가 없습니다.', 'error');
+        showToast(response.message || 'API 응답에 데이터가 없습니다.', 'error');
       }
     } catch (error) {
       console.error('Failed to load customers:', error);
@@ -170,7 +170,7 @@ const CustomersPage = () => {
         loadCustomers();
       } else {
         // 실패 시 에러 메시지 표시
-        showToast(response.error || '고객 정보 수정에 실패했습니다.', 'error');
+        showToast(response.message || '고객 정보 수정에 실패했습니다.', 'error');
       }
     } catch (error) {
       console.error('고객 정보 수정 중 오류 발생:', error);
@@ -194,7 +194,7 @@ const CustomersPage = () => {
         // 목록 새로고침
         loadCustomers();
       } else {
-        showToast(response.error || '고객 정보 삭제에 실패했습니다.', 'error');
+        showToast(response.message || '고객 정보 삭제에 실패했습니다.', 'error');
       }
     } catch (error) {
       console.error('고객 정보 삭제 중 오류 발생:', error);
@@ -236,7 +236,6 @@ const CustomersPage = () => {
       a.click();
       window.URL.revokeObjectURL(url);
       document.body.removeChild(a);
-      showToast('엑셀 템플릿 다운로드 완료', 'success');
     } catch (error) {
       console.error('엑셀 템플릿 다운로드 오류:', error);
       showToast('엑셀 템플릿 다운로드 중 오류가 발생했습니다.', 'error');
@@ -273,7 +272,7 @@ const CustomersPage = () => {
         // 고객 목록 새로고침
         loadCustomers();
       } else {
-        showToast(response.error || '고객 정보 업로드에 실패했습니다.', 'error');
+        showToast(response.message || '고객 정보 업로드에 실패했습니다.', 'error');
       }
     } catch (error) {
       console.error('고객 정보 업로드 오류:', error);

--- a/src/pages/customers/customer.tsx
+++ b/src/pages/customers/customer.tsx
@@ -307,8 +307,10 @@ const CustomersPage = () => {
       header: '연령대',
       render: (customer: Customer) => (
         <div>
-          <div>{customer.ageGroup}대</div>
-          <div className="text-gray-500 text-xs">{customer.gender === 'M' ? '남성' : '여성'}</div>
+          <div>{customer.ageGroup ? `${customer.ageGroup}대` : '선택 안 함'}</div>
+          <div className="text-gray-500 text-xs">
+            {customer.gender === 'M' ? '남성' : customer.gender === 'F' ? '여성' : '선택 안 함'}
+          </div>
         </div>
       ),
     },
@@ -494,9 +496,9 @@ const CustomersPage = () => {
                 name: data.name || selectedCustomer.name,
                 email: data.email || selectedCustomer.email,
                 contact: data.contact || selectedCustomer.contact,
-                ageGroup: Number(data.ageGroup || selectedCustomer.ageGroup),
-                gender: data.gender === 'M' ? 'M' : 'F', // 타입 변환
-                memo: data.memo || '',
+                ageGroup: data.ageGroup !== undefined ? Number(data.ageGroup) : undefined,
+                gender: data.gender !== undefined ? data.gender : undefined,
+                memo: data.memo !== undefined && data.memo !== '' ? data.memo : undefined,
               };
 
               handleUpdateCustomer(requestData);

--- a/src/pages/sms/send.tsx
+++ b/src/pages/sms/send.tsx
@@ -432,7 +432,7 @@ const SmsSendPage = () => {
                                 type="checkbox"
                                 className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
                                 checked={selectedCustomers.some((c) => c.id === customer.id)}
-                                onChange={() => toggleCustomerSelection(customer)}
+                                // onChange={() => toggleCustomerSelection(customer)}
                               />
                             </td>
                           </tr>

--- a/src/types/customer.ts
+++ b/src/types/customer.ts
@@ -6,7 +6,7 @@ export interface Customer {
   email: string;
   contact: string;
   ageGroup?: number; // 선택적
-  gender?: 'M' | 'F'; // 선택적
+  gender?: 'M' | 'F' | undefined; // 선택적
   memo?: string; // 선택적
   createdAt: string;
   updatedAt: string | null;
@@ -19,7 +19,7 @@ export interface CreateCustomerReqDto {
   email: string;
   contact: string;
   ageGroup?: number;
-  gender?: 'M' | 'F';
+  gender?: 'M' | 'F' | undefined;
   memo?: string;
 }
 
@@ -29,7 +29,7 @@ export interface CreateCustomerResDto {
   email: string;
   contact: string;
   ageGroup: number;
-  gender: 'M' | 'F';
+  gender?: 'M' | 'F' | undefined;
   memo?: string;
   createdAt: string;
   updatedAt: string;


### PR DESCRIPTION
## 📌 PR 목적 및 내용
- 문자 발송 페이지에서 고객을 선택하려고 체크박스를 클릭하면 반영이 되지 않는 문제
- 고객 등록 시 연령대, 성별 선택하지 않고 등록했다. 이후, 고객 수정 시 성별만 업데이트하려고 한다. 그런데, 연령대에 대해서 유효성 검증 에러가 발생하면서 성별만 업데이트할 수 없다.
- 고객 등록 시 연령대, 성별 선택 안 한 경우 성별이 여성으로 보여짐.

## ✏️ 변경 사항
- 백엔드에서 customer entity의 update 함수가 null값을 허용하지 않았음
=> nullable 하게 수정
- 프론트엔드의 유효성 검사 스키마에서 undefined를 통과시키지 않게 구성되어 있었음
=> undefilned 허용하게 수정
## 📸 스크린샷 (선택사항)
- UI 변경이나 기능 추가 시 스크린샷을 첨부해주세요.

## ✅ 체크리스트
- [X] 코드가 정상적으로 동작하나요?
- [X] 기존 코드와 충돌이 없나요?
- [ ] 테스트를 통과했나요?
- [ ] 문서 업데이트가 필요한가요?

## 🔗 관련 이슈 (선택사항)
- #53
- #51
- #50
