### PR TITLE
대시보드 버그 수정, 계약 등록 및 상담 등록 페이지 모달 추가, 문의 템플릿 관리 페이지 링크 복사 버튼 추가

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -43,9 +43,6 @@ apiClient.interceptors.response.use(
   (error) => {
     // 에러 처리
     if (error.response) {
-      // 서버가 응답을 반환한 경우
-      console.error('API Error:', error.response.data);
-
       // 공개 경로에서는 401 에러를 무시
       const isPublicPath = publicPaths.some((path) => error.config?.url?.startsWith(path));
 
@@ -54,12 +51,6 @@ apiClient.interceptors.response.use(
         // 로그인 페이지로 리다이렉트 (필요시 구현)
         // window.location.href = '/signin';
       }
-    } else if (error.request) {
-      // 요청이 전송되었으나 응답을 받지 못한 경우
-      console.error('No response received:', error.request);
-    } else {
-      // 요청 설정 중 오류가 발생한 경우
-      console.error('Request error:', error.message);
     }
 
     return Promise.reject(error);

--- a/src/api/consultation.ts
+++ b/src/api/consultation.ts
@@ -17,11 +17,8 @@ export const createConsultation = async (
   data: CreateConsultationReqDto
 ): Promise<ApiResponse<CreateConsultationResDto>> => {
   try {
-    console.log('API 요청 데이터:', data); // 디버깅용 로그 추가
-
     // 프론트엔드 형식(소문자)에서 백엔드 형식(대문자)으로 변환
     const apiData = toApiConsultationDto(data);
-    console.log('변환된 API 요청 데이터:', apiData);
 
     const response = await apiClient.post<ApiResponse<any>>('/consultations', apiData);
 
@@ -32,7 +29,6 @@ export const createConsultation = async (
 
     return response.data as ApiResponse<CreateConsultationResDto>;
   } catch (error) {
-    console.error('상담 생성 API 오류:', error); // 디버깅용 로그 추가
     if (axios.isAxiosError(error) && error.response) {
       return error.response.data as ApiResponse<CreateConsultationResDto>;
     }
@@ -49,9 +45,7 @@ export const createConsultation = async (
  */
 export const getConsultationList = async (): Promise<ApiResponse<ConsultationResDto[]>> => {
   try {
-    console.log('상담 목록 조회 API 호출');
     const response = await apiClient.get<ApiResponse<any[]>>('/consultations');
-    console.log('상담 목록 API 응답:', response.data);
 
     // 백엔드 응답이 성공이면, 데이터가 비어있더라도 성공으로 처리
     if (response.data.success) {
@@ -70,7 +64,6 @@ export const getConsultationList = async (): Promise<ApiResponse<ConsultationRes
       };
     } else {
       // 백엔드에서 명시적으로 실패를 반환한 경우
-      console.log('백엔드에서 실패 응답:', response.data.error);
       return {
         success: true, // 여기를 true로 변경하여 에러 메시지가 표시되지 않도록 함
         error: '데이터가 없습니다.',
@@ -78,7 +71,6 @@ export const getConsultationList = async (): Promise<ApiResponse<ConsultationRes
       };
     }
   } catch (error) {
-    console.error('상담 목록 조회 API 오류:', error);
     // 네트워크 오류 등 실제 API 호출 실패 시에만 에러 반환
     return {
       success: true, // 여기를 true로 변경하여 에러 메시지가 표시되지 않도록 함
@@ -95,9 +87,7 @@ export const getConsultationList = async (): Promise<ApiResponse<ConsultationRes
  */
 export const getConsultationById = async (id: number): Promise<ApiResponse<ConsultationResDto>> => {
   try {
-    console.log(`상담 상세 조회 API 호출: /consultations/${id}`); // 디버깅용 로그 추가
-    const response = await apiClient.get<ApiResponse<any>>(`/consultations/${id}`);
-    console.log('API 응답:', response.data); // 디버깅용 로그 추가
+    const response = await apiClient.get<ApiResponse<ConsultationResDto>>(`/consultations/${id}`);
 
     // 백엔드 응답(대문자)을 프론트엔드 형식(소문자)으로 변환
     if (response.data.success && response.data.data) {
@@ -106,7 +96,6 @@ export const getConsultationById = async (id: number): Promise<ApiResponse<Consu
 
     return response.data as ApiResponse<ConsultationResDto>;
   } catch (error) {
-    console.error('상담 상세 조회 API 오류:', error); // 디버깅용 로그 추가
     if (axios.isAxiosError(error) && error.response) {
       return error.response.data as ApiResponse<ConsultationResDto>;
     }
@@ -128,11 +117,8 @@ export const updateConsultation = async (
   data: CreateConsultationReqDto
 ): Promise<ApiResponse<ConsultationResDto>> => {
   try {
-    console.log('API 수정 요청 데이터:', data); // 디버깅용 로그 추가
-
     // 프론트엔드 형식(소문자)에서 백엔드 형식(대문자)으로 변환
     const apiData = toApiConsultationDto(data);
-    console.log('변환된 API 수정 요청 데이터:', apiData);
 
     const response = await apiClient.put<ApiResponse<any>>(`/consultations/${id}`, apiData);
 
@@ -143,7 +129,6 @@ export const updateConsultation = async (
 
     return response.data as ApiResponse<ConsultationResDto>;
   } catch (error) {
-    console.error('상담 수정 API 오류:', error); // 디버깅용 로그 추가
     if (axios.isAxiosError(error) && error.response) {
       return error.response.data as ApiResponse<ConsultationResDto>;
     }

--- a/src/api/contract.ts
+++ b/src/api/contract.ts
@@ -47,8 +47,7 @@ export const getContracts = async (
 
     const response = await apiClient.get<ApiResponse<ContractListResDto>>(url);
     return response.data;
-  } catch (error) {
-    console.error('Contract API error:', error);
+  } catch {
     return {
       success: false,
       error: '계약 목록을 불러오는 중 오류가 발생했습니다.',

--- a/src/api/customer.ts
+++ b/src/api/customer.ts
@@ -90,15 +90,10 @@ export const deleteMyCustomer = async (id: number): Promise<ApiResponse<CreateCu
 
 // 엑셀 템플릿 다운로드
 export const downloadExcelTemplate = async (): Promise<Blob> => {
-  try {
-    const response = await apiClient.get('/customers/download', {
-      responseType: 'blob',
-    });
-    return response.data;
-  } catch (error) {
-    console.error('엑셀 템플릿 다운로드 오류:', error);
-    throw error;
-  }
+  const response = await apiClient.get('/customers/download', {
+    responseType: 'blob',
+  });
+  return response.data;
 };
 
 // 엑셀 파일로 고객 정보 업로드

--- a/src/components/customers/CustomerSelectionModal.tsx
+++ b/src/components/customers/CustomerSelectionModal.tsx
@@ -1,0 +1,377 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import { X, ChevronLeft, ChevronRight, RefreshCw, Search, User } from 'react-feather';
+import { getMyCustomers } from '../../api/customer';
+import type {
+  CustomerSearchFilter,
+  CustomerListResDto,
+  CreateCustomerResDto,
+} from '../../types/customer';
+import Button from '../ui/Button';
+import Input from '../ui/Input';
+import { useToast } from '../../context/useToast';
+
+interface CustomerSelectionModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSelectCustomer: (customer: CreateCustomerResDto) => void;
+  selectedCustomerId?: number | null;
+}
+
+const CustomerSelectionModal: React.FC<CustomerSelectionModalProps> = ({
+  isOpen,
+  onClose,
+  onSelectCustomer,
+  selectedCustomerId = null,
+}) => {
+  const { showToast } = useToast();
+  const [loading, setLoading] = useState(false);
+  const [customers, setCustomers] = useState<CustomerListResDto | null>(null);
+  const [selectedId, setSelectedId] = useState<number | null>(selectedCustomerId);
+
+  // 검색 필터 상태
+  const [filter, setFilter] = useState<CustomerSearchFilter>({
+    page: 1,
+    size: 8,
+    keyword: '',
+  });
+
+  // 검색 입력값 상태 (즉시 API 호출하지 않기 위해 별도 관리)
+  const [searchKeyword, setSearchKeyword] = useState('');
+  const [searchBtnClicked, setSearchBtnClicked] = useState(false);
+
+  // 모달이 열릴 때 selectedId 초기화
+  useEffect(() => {
+    if (isOpen) {
+      setSelectedId(selectedCustomerId);
+    }
+  }, [isOpen, selectedCustomerId]);
+
+  // 고객 목록 로드
+  const loadCustomers = async () => {
+    setLoading(true);
+    try {
+      const response = await getMyCustomers(filter);
+      if (response.success && response.data) {
+        setCustomers(response.data);
+      } else {
+        showToast(response.error || '고객 목록을 불러오는데 실패했습니다.', 'error');
+      }
+    } catch {
+      showToast('고객 목록을 불러오는 중 오류가 발생했습니다.', 'error');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // 모달이 열릴 때 고객 목록 로드
+  useEffect(() => {
+    if (isOpen) {
+      loadCustomers();
+    }
+  }, [isOpen, filter.page]);
+
+  useEffect(() => {
+    if (searchBtnClicked) {
+      loadCustomers();
+      setSearchBtnClicked(false);
+    }
+  }, [searchBtnClicked]);
+
+  // 검색 버튼 클릭 핸들러
+  const handleSearch = (e: React.FormEvent) => {
+    e.preventDefault(); // 폼 제출 기본 동작 방지
+
+    setFilter({
+      ...filter,
+      page: 1, // 검색 시 첫 페이지로 리셋
+      keyword: searchKeyword,
+    });
+    setSearchBtnClicked(true);
+  };
+
+  // 필터 초기화 함수
+  const resetFilters = () => {
+    setSearchKeyword('');
+    setFilter({
+      page: 1,
+      size: 8,
+      keyword: '',
+    });
+    setSearchBtnClicked(true);
+  };
+
+  // 페이지 변경 핸들러
+  const handlePageChange = (newPage: number) => {
+    setFilter({
+      ...filter,
+      page: newPage,
+    });
+  };
+
+  // 고객 선택 핸들러
+  const handleSelectCustomer = (customerId: number) => {
+    setSelectedId(customerId);
+  };
+
+  // 선택 확인 핸들러
+  const handleConfirmSelection = () => {
+    if (selectedId && customers) {
+      const selectedCustomer = customers.content.find((customer) => customer.id === selectedId);
+      if (selectedCustomer) {
+        onSelectCustomer(selectedCustomer);
+        onClose();
+      } else {
+        showToast('선택한 고객 정보를 찾을 수 없습니다.', 'error');
+      }
+    } else {
+      showToast('고객을 선택해주세요.', 'error');
+    }
+  };
+
+  // 모달 외부 클릭 방지
+  const handleModalClick = (e: React.MouseEvent) => {
+    // 모달 내부 클릭 시 이벤트 전파 중단
+    e.stopPropagation();
+  };
+
+  // 모달이 닫혀있으면 렌더링하지 않음
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50"
+      onClick={onClose} // 모달 외부 클릭 시 닫기
+    >
+      <div
+        className="bg-white rounded-lg shadow-xl w-full max-w-4xl max-h-[90vh] flex flex-col"
+        onClick={handleModalClick} // 모달 내부 클릭 시 이벤트 전파 중단
+      >
+        {/* 모달 헤더 */}
+        <div className="flex justify-between items-center p-4 border-b">
+          <h2 className="text-xl font-semibold">고객 선택</h2>
+          <button
+            onClick={(e) => {
+              e.stopPropagation(); // 이벤트 전파 중단
+              onClose();
+            }}
+            className="text-gray-500 hover:text-gray-700"
+            aria-label="닫기"
+          >
+            <X size={24} />
+          </button>
+        </div>
+
+        {/* 검색 필터 */}
+        <div className="p-4 border-b">
+          <form onSubmit={handleSearch} className="space-y-4">
+            <div className="flex gap-3">
+              <div className="flex-1">
+                <Input
+                  placeholder="고객 이름 또는 연락처 검색"
+                  value={searchKeyword}
+                  onChange={(e) => setSearchKeyword(e.target.value)}
+                  leftIcon={<Search size={18} />}
+                />
+              </div>
+              <Button
+                type="submit"
+                variant="primary"
+                onClick={(e) => e.stopPropagation()} // 이벤트 전파 중단
+              >
+                검색
+              </Button>
+            </div>
+
+            <div className="flex justify-end">
+              <div className="flex gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={(e) => {
+                    e.stopPropagation(); // 이벤트 전파 중단
+                    resetFilters();
+                  }}
+                >
+                  필터 초기화
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={(e) => {
+                    e.stopPropagation(); // 이벤트 전파 중단
+                    setSearchBtnClicked(true);
+                  }}
+                  leftIcon={<RefreshCw size={14} />}
+                >
+                  새로고침
+                </Button>
+              </div>
+            </div>
+          </form>
+        </div>
+
+        {/* 고객 목록 */}
+        <div className="flex-1 overflow-y-auto p-4">
+          {loading ? (
+            <div className="flex justify-center items-center h-64">
+              <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-blue-500"></div>
+            </div>
+          ) : customers && customers.content.length > 0 ? (
+            <div className="grid grid-cols-1 gap-3">
+              {customers.content.map((customer) => (
+                <div
+                  key={customer.id}
+                  className={`border rounded-lg p-3 transition-colors cursor-pointer
+                    ${selectedId === customer.id ? 'bg-blue-50 border-blue-500' : 'hover:bg-gray-50 border-gray-200'}`}
+                  onClick={(e) => {
+                    e.stopPropagation(); // 이벤트 전파 중단
+                    handleSelectCustomer(customer.id);
+                  }}
+                >
+                  <div className="flex justify-between items-center">
+                    <div className="flex-1">
+                      <div className="flex items-center">
+                        <div className="w-10 h-10 rounded-full bg-gray-200 flex items-center justify-center mr-3">
+                          <User size={20} className="text-gray-500" />
+                        </div>
+                        <div>
+                          <p className="font-medium">{customer.name}</p>
+                          <p className="text-sm text-gray-500">{customer.contact}</p>
+                        </div>
+                      </div>
+                    </div>
+                    <div className="flex items-center">
+                      <Button
+                        variant={selectedId === customer.id ? 'primary' : 'outline'}
+                        size="sm"
+                        onClick={(e) => {
+                          e.stopPropagation(); // 이벤트 전파 중단
+                          handleSelectCustomer(customer.id);
+                        }}
+                        className="transition-colors"
+                      >
+                        {selectedId === customer.id ? '선택됨' : '선택'}
+                      </Button>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="flex flex-col items-center justify-center h-64 text-gray-500">
+              <User size={48} className="text-gray-300 mb-4" />
+              <p>검색 결과가 없습니다.</p>
+            </div>
+          )}
+        </div>
+
+        {/* 페이지네이션 */}
+        {customers && customers.pagination.totalPages > 1 && (
+          <div className="p-4 border-t flex justify-center">
+            <div className="flex items-center space-x-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={(e) => {
+                  e.stopPropagation(); // 이벤트 전파 중단
+                  handlePageChange(Math.max(1, filter.page - 1));
+                }}
+                disabled={filter.page === 1}
+              >
+                <ChevronLeft size={16} />
+              </Button>
+
+              <div className="flex items-center space-x-1">
+                {Array.from({ length: customers.pagination.totalPages }, (_, i) => i + 1)
+                  .filter((page) => {
+                    // 현재 페이지 주변 5개 페이지만 표시
+                    const currentPage = filter.page;
+                    return (
+                      page === 1 ||
+                      page === customers.pagination.totalPages ||
+                      (page >= currentPage - 2 && page <= currentPage + 2)
+                    );
+                  })
+                  .map((page, index, array) => {
+                    // 생략 부분 표시
+                    if (index > 0 && array[index - 1] !== page - 1) {
+                      return (
+                        <React.Fragment key={`ellipsis-${page}`}>
+                          <span className="px-2">...</span>
+                          <Button
+                            key={page}
+                            variant={filter.page === page ? 'primary' : 'outline'}
+                            size="sm"
+                            onClick={(e) => {
+                              e.stopPropagation(); // 이벤트 전파 중단
+                              handlePageChange(page);
+                            }}
+                            className="min-w-[32px]"
+                          >
+                            {page}
+                          </Button>
+                        </React.Fragment>
+                      );
+                    }
+                    return (
+                      <Button
+                        key={page}
+                        variant={filter.page === page ? 'primary' : 'outline'}
+                        size="sm"
+                        onClick={(e) => {
+                          e.stopPropagation(); // 이벤트 전파 중단
+                          handlePageChange(page);
+                        }}
+                        className="min-w-[32px]"
+                      >
+                        {page}
+                      </Button>
+                    );
+                  })}
+              </div>
+
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={(e) => {
+                  e.stopPropagation(); // 이벤트 전파 중단
+                  handlePageChange(Math.min(customers.pagination.totalPages, filter.page + 1));
+                }}
+                disabled={filter.page === customers.pagination.totalPages}
+              >
+                <ChevronRight size={16} />
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {/* 하단 버튼 */}
+        <div className="p-4 border-t flex justify-end space-x-2">
+          <Button
+            variant="outline"
+            onClick={(e) => {
+              e.stopPropagation(); // 이벤트 전파 중단
+              onClose();
+            }}
+          >
+            취소
+          </Button>
+          <Button
+            variant="primary"
+            onClick={(e) => {
+              e.stopPropagation(); // 이벤트 전파 중단
+              handleConfirmSelection();
+            }}
+            disabled={!selectedId}
+          >
+            선택 완료
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CustomerSelectionModal;

--- a/src/components/customers/CustomerSelectionModal.tsx
+++ b/src/components/customers/CustomerSelectionModal.tsx
@@ -141,7 +141,7 @@ const CustomerSelectionModal: React.FC<CustomerSelectionModalProps> = ({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50"
+      className="fixed inset-0 z-50 flex items-center justify-center "
       onClick={onClose} // 모달 외부 클릭 시 닫기
     >
       <div

--- a/src/components/inquiryTemplate/InquiryTemplateList.tsx
+++ b/src/components/inquiryTemplate/InquiryTemplateList.tsx
@@ -3,8 +3,9 @@
 import type React from 'react';
 import { format } from 'date-fns';
 import { ko } from 'date-fns/locale';
-import { Edit, Eye, Trash } from 'react-feather';
+import { Copy, Edit, Eye, Trash } from 'react-feather';
 import type { InquiryTemplate } from '../../types/inquiryTemplate';
+import { ToastVariant } from '../../hooks/useToast';
 
 interface InquiryTemplateListProps {
   inquiryTemplates: InquiryTemplate[];
@@ -12,6 +13,7 @@ interface InquiryTemplateListProps {
   onPreview: (inquiryTemplate: InquiryTemplate) => void;
   onDelete: (inquiryTemplate: InquiryTemplate) => void;
   isLoading: boolean;
+  showToast: (message: string, variant: ToastVariant, duration: number) => void;
 }
 
 const InquiryTemplateList: React.FC<InquiryTemplateListProps> = ({
@@ -20,6 +22,7 @@ const InquiryTemplateList: React.FC<InquiryTemplateListProps> = ({
   onPreview,
   onDelete,
   isLoading,
+  showToast,
 }) => {
   const formatDate = (dateString: string) => {
     try {
@@ -33,6 +36,16 @@ const InquiryTemplateList: React.FC<InquiryTemplateListProps> = ({
   const truncateDescription = (text: string, maxLength = 50) => {
     if (text.length <= maxLength) return text;
     return text.substring(0, maxLength) + '...';
+  };
+
+  const handleCopyLink = (shareToken: string) => {
+    const link = `${window.location.origin}/inquiry/share/${shareToken}`;
+    navigator.clipboard
+      .writeText(link)
+      .then(() =>
+        showToast('고객이 접근 가능한 문의 폼 링크가 클립보드에 복사되었습니다.', 'success', 3000)
+      )
+      .catch(() => showToast('복사에 실패했습니다.', 'error', 3000));
   };
 
   if (isLoading) {
@@ -123,24 +136,31 @@ const InquiryTemplateList: React.FC<InquiryTemplateListProps> = ({
                 <div className="relative flex justify-end items-center space-x-2">
                   <button
                     onClick={() => onPreview(inquiryTemplate)}
-                    className="text-blue-600 hover:text-blue-900"
+                    className="text-blue-600 hover:text-blue-900 cursor-pointer"
                     title="미리보기"
                   >
                     <Eye size={18} />
                   </button>
                   <button
                     onClick={() => onEdit(inquiryTemplate)}
-                    className="text-indigo-600 hover:text-indigo-900"
+                    className="text-indigo-600 hover:text-indigo-900 cursor-pointer"
                     title="수정"
                   >
                     <Edit size={18} />
                   </button>
                   <button
                     onClick={() => onDelete(inquiryTemplate)}
-                    className="text-red-600 hover:text-red-900"
+                    className="text-red-600 hover:text-red-900 cursor-pointer"
                     title="삭제"
                   >
                     <Trash size={18} />
+                  </button>
+                  <button
+                    onClick={() => handleCopyLink(inquiryTemplate.shareToken)}
+                    className="text-gray-600 hover:text-gray-900 cursor-pointer"
+                    title="링크 복사"
+                  >
+                    <Copy size={18} />
                   </button>
                 </div>
               </td>

--- a/src/components/property/PropertySelectionModal.tsx
+++ b/src/components/property/PropertySelectionModal.tsx
@@ -168,7 +168,7 @@ const PropertySelectionModal: React.FC<PropertySelectionModalProps> = ({
       aria-modal="true"
     >
       <div
-        className="fixed inset-0 z-50 flex items-center justify-center bg-gray-50"
+        className="fixed inset-0 z-50 flex items-center justify-center"
         onClick={onClose} // 모달 외부 클릭 시 닫기
       >
         <div

--- a/src/components/property/PropertySelectionModal.tsx
+++ b/src/components/property/PropertySelectionModal.tsx
@@ -1,0 +1,420 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import { X, ChevronLeft, ChevronRight, RefreshCw } from 'react-feather';
+import { getProperties } from '../../api/property';
+import {
+  type PropertySearchFilter,
+  type PropertyListResDto,
+  type PropertyType,
+  PropertyTypeLabels,
+  FindPropertyResDto,
+} from '../../types/property';
+import Button from '../ui/Button';
+import Input from '../ui/Input';
+import { useToast } from '../../context/useToast';
+import PropertyTypeFilter from '../property/PropertyTypeFilter';
+
+interface PropertySelectionModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSelectProperty: (property: FindPropertyResDto) => void;
+}
+
+const PropertySelectionModal: React.FC<PropertySelectionModalProps> = ({
+  isOpen,
+  onClose,
+  onSelectProperty,
+}) => {
+  const { showToast } = useToast();
+  const [loading, setLoading] = useState(false);
+  const [properties, setProperties] = useState<PropertyListResDto | null>(null);
+  const [selectedPropertyId, setSelectedPropertyId] = useState<number | null>(null);
+
+  // 검색 필터 상태
+  const [filter, setFilter] = useState<PropertySearchFilter>({
+    page: 1,
+    size: 8,
+    propertyType: null,
+    province: '',
+    city: '',
+    dong: '',
+  });
+
+  // 검색 입력값 상태 (즉시 API 호출하지 않기 위해 별도 관리)
+  const [provinceInput, setProvinceInput] = useState('');
+  const [cityInput, setCityInput] = useState('');
+  const [dongInput, setDongInput] = useState('');
+  const [searchBtnClicked, setSearchBtnClicked] = useState(false);
+
+  // 모달이 열릴 때 selectedPropertyId 초기화
+  useEffect(() => {
+    if (isOpen) {
+      setSelectedPropertyId(null);
+    }
+  }, [isOpen]);
+
+  // 매물 목록 로드
+  const loadProperties = async () => {
+    setLoading(true);
+    try {
+      const response = await getProperties(filter);
+      if (response.success && response.data) {
+        setProperties(response.data);
+      } else {
+        showToast(response.error || '매물 목록을 불러오는데 실패했습니다.', 'error');
+      }
+    } catch {
+      showToast('매물 목록을 불러오는 중 오류가 발생했습니다.', 'error');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // 모달이 열릴 때 매물 목록 로드
+  useEffect(() => {
+    if (isOpen) {
+      loadProperties();
+    }
+  }, [isOpen, filter.page]);
+
+  useEffect(() => {
+    if (searchBtnClicked) {
+      loadProperties();
+      setSearchBtnClicked(false);
+    }
+  }, [searchBtnClicked]);
+
+  // 검색 버튼 클릭 핸들러
+  const handleSearch = (e: React.FormEvent) => {
+    e.preventDefault(); // 폼 제출 기본 동작 방지
+
+    setFilter({
+      ...filter,
+      page: 1, // 검색 시 첫 페이지로 리셋
+      province: provinceInput,
+      city: cityInput,
+      dong: dongInput,
+    });
+    setSearchBtnClicked(true);
+  };
+
+  // 필터 초기화 함수
+  const resetFilters = () => {
+    setProvinceInput('');
+    setCityInput('');
+    setDongInput('');
+    setFilter({
+      page: 1,
+      size: 8,
+      propertyType: null,
+      province: '',
+      city: '',
+      dong: '',
+    });
+    setSearchBtnClicked(true);
+  };
+
+  // 페이지 변경 핸들러
+  const handlePageChange = (newPage: number) => {
+    setFilter({
+      ...filter,
+      page: newPage,
+    });
+  };
+
+  // 매물 유형 변경 핸들러
+  const handlePropertyTypeChange = (type: PropertyType | null) => {
+    setFilter((prev) => ({ ...prev, propertyType: type, page: 1 }));
+    setSearchBtnClicked(true);
+  };
+
+  // 매물 선택 핸들러
+  const handleSelectProperty = (propertyId: number) => {
+    setSelectedPropertyId(propertyId);
+  };
+
+  // 선택 확인 핸들러
+  const handleConfirmSelection = () => {
+    if (selectedPropertyId && properties) {
+      const selectedProperty = properties.content.find(
+        (property) => property.id === selectedPropertyId
+      );
+      if (selectedProperty) {
+        onSelectProperty(selectedProperty);
+        onClose();
+      } else {
+        showToast('선택한 매물 정보를 찾을 수 없습니다.', 'error');
+      }
+    } else {
+      showToast('매물을 선택해주세요.', 'error');
+    }
+  };
+
+  // 모달 외부 클릭 방지
+  const handleModalClick = (e: React.MouseEvent) => {
+    // 모달 내부 클릭 시 이벤트 전파 중단
+    e.stopPropagation();
+  };
+
+  // 모달이 닫혀있으면 렌더링하지 않음
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 overflow-y-auto"
+      aria-labelledby="modal-title"
+      role="dialog"
+      aria-modal="true"
+    >
+      <div
+        className="fixed inset-0 z-50 flex items-center justify-center bg-gray-50"
+        onClick={onClose} // 모달 외부 클릭 시 닫기
+      >
+        <div
+          className="bg-white rounded-lg shadow-xl w-full max-w-4xl max-h-[90vh] flex flex-col"
+          onClick={handleModalClick} // 모달 내부 클릭 시 이벤트 전파 중단
+        >
+          {/* 모달 헤더 */}
+          <div className="flex justify-between items-center p-4 border-b">
+            <h2 className="text-xl font-semibold">매물 선택</h2>
+            <button
+              onClick={(e) => {
+                e.stopPropagation(); // 이벤트 전파 중단
+                onClose();
+              }}
+              className="text-gray-500 hover:text-gray-700"
+              aria-label="닫기"
+            >
+              <X size={24} />
+            </button>
+          </div>
+
+          {/* 검색 필터 */}
+          <div className="p-4 border-b">
+            <form onSubmit={handleSearch} className="space-y-4">
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+                <Input
+                  placeholder="도/특별시/광역시"
+                  value={provinceInput}
+                  onChange={(e) => setProvinceInput(e.target.value)}
+                />
+                <Input
+                  placeholder="시/군/구"
+                  value={cityInput}
+                  onChange={(e) => setCityInput(e.target.value)}
+                />
+                <Input
+                  placeholder="읍/면/동"
+                  value={dongInput}
+                  onChange={(e) => setDongInput(e.target.value)}
+                />
+              </div>
+
+              <div className="flex justify-between">
+                <Button
+                  type="submit"
+                  variant="primary"
+                  onClick={(e) => e.stopPropagation()} // 이벤트 전파 중단
+                >
+                  검색
+                </Button>
+                <div className="flex gap-2">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={(e) => {
+                      e.stopPropagation(); // 이벤트 전파 중단
+                      resetFilters();
+                    }}
+                  >
+                    필터 초기화
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={(e) => {
+                      e.stopPropagation(); // 이벤트 전파 중단
+                      setSearchBtnClicked(true);
+                    }}
+                    leftIcon={<RefreshCw size={14} />}
+                  >
+                    새로고침
+                  </Button>
+                </div>
+              </div>
+            </form>
+
+            <div className="mt-4">
+              <PropertyTypeFilter
+                selectedType={filter.propertyType}
+                onChange={handlePropertyTypeChange}
+              />
+            </div>
+          </div>
+
+          {/* 매물 목록 */}
+          <div className="flex-1 overflow-y-auto p-4">
+            {loading ? (
+              <div className="flex justify-center items-center h-64">
+                <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-blue-500"></div>
+              </div>
+            ) : properties && properties.content.length > 0 ? (
+              <div className="grid grid-cols-1 gap-3">
+                {properties.content.map((property) => (
+                  <div
+                    key={property.id}
+                    className={`border rounded-lg p-3 transition-colors cursor-pointer
+                    ${
+                      selectedPropertyId === property.id
+                        ? 'bg-blue-50 border-blue-500'
+                        : 'hover:bg-gray-50 border-gray-200'
+                    }`}
+                    onClick={(e) => {
+                      e.stopPropagation(); // 이벤트 전파 중단
+                      handleSelectProperty(property.id);
+                    }}
+                  >
+                    <div className="flex justify-between items-center">
+                      <div className="flex-1">
+                        <p className="font-medium">{property.roadAddress}</p>
+                        <p className="text-sm text-gray-500">{property.detailAddress}</p>
+                        <div className="mt-1 flex items-center flex-wrap gap-2">
+                          <span className="inline-block px-2 py-1 text-xs bg-gray-100 text-gray-800 rounded-full">
+                            {PropertyTypeLabels[property.propertyType]}
+                          </span>
+                        </div>
+                      </div>
+                      <div className="flex items-center">
+                        <Button
+                          variant={selectedPropertyId === property.id ? 'primary' : 'outline'}
+                          size="sm"
+                          onClick={(e) => {
+                            e.stopPropagation(); // 이벤트 전파 중단
+                            handleSelectProperty(property.id);
+                          }}
+                          className="transition-colors"
+                        >
+                          {selectedPropertyId === property.id ? '선택됨' : '선택'}
+                        </Button>
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="flex flex-col items-center justify-center h-64 text-gray-500">
+                <p>검색 결과가 없습니다.</p>
+              </div>
+            )}
+          </div>
+
+          {/* 페이지네이션 */}
+          {properties?.pagination && properties.pagination.totalPages > 1 && (
+            <div className="p-4 border-t flex justify-center">
+              <div className="flex items-center space-x-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={(e) => {
+                    e.stopPropagation(); // 이벤트 전파 중단
+                    handlePageChange(Math.max(1, filter.page - 1));
+                  }}
+                  disabled={filter.page === 1}
+                >
+                  <ChevronLeft size={16} />
+                </Button>
+
+                <div className="flex items-center space-x-1">
+                  {Array.from({ length: properties.pagination.totalPages }, (_, i) => i + 1)
+                    .filter((page) => {
+                      // 현재 페이지 주변 5개 페이지만 표시
+                      const currentPage = filter.page;
+                      return (
+                        page === 1 ||
+                        page === properties.pagination.totalPages ||
+                        (page >= currentPage - 2 && page <= currentPage + 2)
+                      );
+                    })
+                    .map((page, index, array) => {
+                      // 생략 부분 표시
+                      if (index > 0 && array[index - 1] !== page - 1) {
+                        return (
+                          <React.Fragment key={`ellipsis-${page}`}>
+                            <span className="px-2">...</span>
+                            <Button
+                              key={page}
+                              variant={filter.page === page ? 'primary' : 'outline'}
+                              size="sm"
+                              onClick={(e) => {
+                                e.stopPropagation(); // 이벤트 전파 중단
+                                handlePageChange(page);
+                              }}
+                              className="min-w-[32px]"
+                            >
+                              {page}
+                            </Button>
+                          </React.Fragment>
+                        );
+                      }
+                      return (
+                        <Button
+                          key={page}
+                          variant={filter.page === page ? 'primary' : 'outline'}
+                          size="sm"
+                          onClick={(e) => {
+                            e.stopPropagation(); // 이벤트 전파 중단
+                            handlePageChange(page);
+                          }}
+                          className="min-w-[32px]"
+                        >
+                          {page}
+                        </Button>
+                      );
+                    })}
+                </div>
+
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={(e) => {
+                    e.stopPropagation(); // 이벤트 전파 중단
+                    handlePageChange(Math.min(properties.pagination.totalPages, filter.page + 1));
+                  }}
+                  disabled={filter.page === properties.pagination.totalPages}
+                >
+                  <ChevronRight size={16} />
+                </Button>
+              </div>
+            </div>
+          )}
+
+          {/* 하단 버튼 */}
+          <div className="p-4 border-t flex justify-end space-x-2">
+            <Button
+              variant="outline"
+              onClick={(e) => {
+                e.stopPropagation(); // 이벤트 전파 중단
+                onClose();
+              }}
+            >
+              취소
+            </Button>
+            <Button
+              variant="primary"
+              onClick={(e) => {
+                e.stopPropagation(); // 이벤트 전파 중단
+                handleConfirmSelection();
+              }}
+              disabled={!selectedPropertyId}
+            >
+              선택 완료
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PropertySelectionModal;

--- a/src/components/property/PropertySelectionModal.tsx
+++ b/src/components/property/PropertySelectionModal.tsx
@@ -19,17 +19,19 @@ interface PropertySelectionModalProps {
   isOpen: boolean;
   onClose: () => void;
   onSelectProperty: (property: FindPropertyResDto) => void;
+  selectedPropertyId?: number | null;
 }
 
 const PropertySelectionModal: React.FC<PropertySelectionModalProps> = ({
   isOpen,
   onClose,
   onSelectProperty,
+  selectedPropertyId = null,
 }) => {
   const { showToast } = useToast();
   const [loading, setLoading] = useState(false);
   const [properties, setProperties] = useState<PropertyListResDto | null>(null);
-  const [selectedPropertyId, setSelectedPropertyId] = useState<number | null>(null);
+  const [selectedId, setSelectedId] = useState<number | null>(null);
 
   // 검색 필터 상태
   const [filter, setFilter] = useState<PropertySearchFilter>({
@@ -50,9 +52,9 @@ const PropertySelectionModal: React.FC<PropertySelectionModalProps> = ({
   // 모달이 열릴 때 selectedPropertyId 초기화
   useEffect(() => {
     if (isOpen) {
-      setSelectedPropertyId(null);
+      setSelectedId(selectedPropertyId);
     }
-  }, [isOpen]);
+  }, [isOpen, selectedPropertyId]);
 
   // 매물 목록 로드
   const loadProperties = async () => {
@@ -131,15 +133,13 @@ const PropertySelectionModal: React.FC<PropertySelectionModalProps> = ({
 
   // 매물 선택 핸들러
   const handleSelectProperty = (propertyId: number) => {
-    setSelectedPropertyId(propertyId);
+    setSelectedId(propertyId);
   };
 
   // 선택 확인 핸들러
   const handleConfirmSelection = () => {
-    if (selectedPropertyId && properties) {
-      const selectedProperty = properties.content.find(
-        (property) => property.id === selectedPropertyId
-      );
+    if (selectedId && properties) {
+      const selectedProperty = properties.content.find((property) => property.id === selectedId);
       if (selectedProperty) {
         onSelectProperty(selectedProperty);
         onClose();
@@ -266,7 +266,7 @@ const PropertySelectionModal: React.FC<PropertySelectionModalProps> = ({
                     key={property.id}
                     className={`border rounded-lg p-3 transition-colors cursor-pointer
                     ${
-                      selectedPropertyId === property.id
+                      selectedId === property.id
                         ? 'bg-blue-50 border-blue-500'
                         : 'hover:bg-gray-50 border-gray-200'
                     }`}
@@ -287,7 +287,7 @@ const PropertySelectionModal: React.FC<PropertySelectionModalProps> = ({
                       </div>
                       <div className="flex items-center">
                         <Button
-                          variant={selectedPropertyId === property.id ? 'primary' : 'outline'}
+                          variant={selectedId === property.id ? 'primary' : 'outline'}
                           size="sm"
                           onClick={(e) => {
                             e.stopPropagation(); // 이벤트 전파 중단
@@ -295,7 +295,7 @@ const PropertySelectionModal: React.FC<PropertySelectionModalProps> = ({
                           }}
                           className="transition-colors"
                         >
-                          {selectedPropertyId === property.id ? '선택됨' : '선택'}
+                          {selectedId === property.id ? '선택됨' : '선택'}
                         </Button>
                       </div>
                     </div>
@@ -406,7 +406,7 @@ const PropertySelectionModal: React.FC<PropertySelectionModalProps> = ({
                 e.stopPropagation(); // 이벤트 전파 중단
                 handleConfirmSelection();
               }}
-              disabled={!selectedPropertyId}
+              disabled={!selectedId}
             >
               선택 완료
             </Button>

--- a/src/pages/consultation/ConsultationDetailPage.tsx
+++ b/src/pages/consultation/ConsultationDetailPage.tsx
@@ -36,9 +36,6 @@ const ConsultationDetailPage: React.FC = () => {
 
     setLoading(true);
     try {
-      // 디버깅을 위한 로그 추가
-      console.log('조회할 상담 ID:', id);
-
       const consultationId = Number.parseInt(id);
       if (isNaN(consultationId)) {
         showToast('유효하지 않은 상담 ID 형식입니다.', 'error');
@@ -47,7 +44,6 @@ const ConsultationDetailPage: React.FC = () => {
       }
 
       const response = await getConsultationById(consultationId);
-      console.log('상담 상세 조회 응답:', response); // 디버깅용 로그 추가
 
       if (response.success && response.data) {
         setConsultation(response.data);
@@ -214,9 +210,21 @@ const ConsultationDetailPage: React.FC = () => {
         <div className="border-t border-gray-200 px-4 py-5 sm:p-0">
           <dl className="sm:divide-y sm:divide-gray-200">
             <div className="py-4 sm:py-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
-              <dt className="text-sm font-medium text-gray-500">고객 ID</dt>
+              <dt className="text-sm font-medium text-gray-500">고객 이름</dt>
               <dd className="mt-1 text-sm text-gray-900 sm:mt-0 sm:col-span-2">
-                {consultation.customerId}
+                {consultation.customer.name}
+              </dd>
+            </div>
+            <div className="py-4 sm:py-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
+              <dt className="text-sm font-medium text-gray-500">고객 전화번호</dt>
+              <dd className="mt-1 text-sm text-gray-900 sm:mt-0 sm:col-span-2">
+                {consultation.customer.contact}
+              </dd>
+            </div>
+            <div className="py-4 sm:py-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
+              <dt className="text-sm font-medium text-gray-500">고객 이메일</dt>
+              <dd className="mt-1 text-sm text-gray-900 sm:mt-0 sm:col-span-2">
+                {consultation.customer.email}
               </dd>
             </div>
             <div className="py-4 sm:py-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">

--- a/src/pages/consultation/ConsultationFormPage.tsx
+++ b/src/pages/consultation/ConsultationFormPage.tsx
@@ -4,7 +4,10 @@ import type React from 'react';
 import { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { Calendar, ArrowLeft, FileText, User, Edit } from 'react-feather';
-import type { CreateConsultationReqDto } from '../../types/consultation';
+import type {
+  ConsultationCustomerResDto,
+  CreateConsultationReqDto,
+} from '../../types/consultation';
 import type { CreateCustomerResDto } from '../../types/customer';
 import {
   getConsultationById,
@@ -40,7 +43,7 @@ const ConsultationFormPage: React.FC = () => {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [isCustomerModalOpen, setIsCustomerModalOpen] = useState(false);
-  const [selectedCustomer, setSelectedCustomer] = useState<CreateCustomerResDto | null>(null);
+  const [selectedCustomer, setSelectedCustomer] = useState<ConsultationCustomerResDto | null>(null);
 
   useEffect(() => {
     // 에이전트 ID 설정
@@ -60,7 +63,7 @@ const ConsultationFormPage: React.FC = () => {
             const consultation = response.data;
             setFormData({
               agentId: consultation.agentId,
-              customerId: consultation.customerId,
+              customerId: consultation.customer.id,
               consultationType: consultation.consultationType,
               content: consultation.content || '',
               consultationDate: consultation.consultationDate || new Date().toISOString(),
@@ -68,9 +71,9 @@ const ConsultationFormPage: React.FC = () => {
             });
 
             // 고객 정보가 있으면 설정
-            // if (consultation.customerId) {
-            //   setSelectedCustomer(consultation.customer);
-            // }
+            if (consultation.customer) {
+              setSelectedCustomer(consultation.customer);
+            }
           } else {
             showToast(response.error || '상담 정보를 불러오는데 실패했습니다.', 'error');
             navigate('/consultations', { replace: true });

--- a/src/pages/consultation/ConsultationListPage.tsx
+++ b/src/pages/consultation/ConsultationListPage.tsx
@@ -39,9 +39,7 @@ const ConsultationListPage: React.FC = () => {
     setNoData(false);
 
     try {
-      console.log('상담 목록 조회 시작');
       const response = await getConsultationList();
-      console.log('상담 목록 조회 응답:', response);
 
       // 응답이 성공이면 (API에서 항상 success: true를 반환하도록 수정함)
       if (response.success) {
@@ -50,25 +48,21 @@ const ConsultationListPage: React.FC = () => {
           setConsultations(response.data);
           setFilteredConsultations(response.data);
           setNoData(false);
-          console.log('상담 목록 조회 성공:', response.data);
         }
         // 데이터가 없는 경우 (빈 배열)
         else {
           setConsultations([]);
           setFilteredConsultations([]);
           setNoData(true);
-          console.log('상담 내역이 없습니다.');
         }
       } else {
         // API 호출은 성공했지만 백엔드에서 오류 응답을 준 경우 (이 경우는 발생하지 않아야 함)
-        console.error('API 응답 오류:', response.error);
         setConsultations([]);
         setFilteredConsultations([]);
         setNoData(true);
       }
-    } catch (error) {
+    } catch {
       // 이 부분은 실행되지 않아야 함 (API에서 항상 success: true를 반환하도록 수정함)
-      console.error('상담 목록 조회 중 예외 발생:', error);
       setConsultations([]);
       setFilteredConsultations([]);
       setNoData(true);
@@ -96,15 +90,15 @@ const ConsultationListPage: React.FC = () => {
     }
   }, [searchTerm, filters, consultations]);
 
-  // 검색 기능 단순화 - 고객 ID와 내용으로만 검색
+  // 검색 기능 단순화 - 고객 이름과 내용으로만 검색
   const applyFilters = () => {
     let filtered = [...consultations];
 
-    // 검색어 필터링 (고객 ID로 검색)
+    // 검색어 필터링 (고객 이름으로 검색)
     if (searchTerm) {
       filtered = filtered.filter(
         (item) =>
-          item.customerId.toString().includes(searchTerm) ||
+          item.customer.name.toString().includes(searchTerm) ||
           (item.content && item.content.toLowerCase().includes(searchTerm.toLowerCase()))
       );
     }
@@ -231,7 +225,7 @@ const ConsultationListPage: React.FC = () => {
             <div className="relative flex-grow">
               <input
                 type="text"
-                placeholder="고객 ID 또는 내용으로 검색"
+                placeholder="고객 이름 또는 내용으로 검색"
                 className="w-full px-4 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
                 value={searchTerm}
                 onChange={(e) => setSearchTerm(e.target.value)}
@@ -322,16 +316,19 @@ const ConsultationListPage: React.FC = () => {
                   상담일
                 </th>
                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  고객 ID
+                  고객 이름
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  고객 전화번호
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  고객 이메일
                 </th>
                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                   상담유형
                 </th>
                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                   상담상태
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  내용
                 </th>
                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                   등록일
@@ -360,7 +357,6 @@ const ConsultationListPage: React.FC = () => {
                     className="hover:bg-gray-50 cursor-pointer"
                     onClick={() => {
                       const id = consultation.id;
-                      console.log('consultation.id:', consultation.id, typeof consultation.id); // 여기서 체크
                       if (typeof id === 'number' && !isNaN(id)) {
                         navigate(`/consultations/${consultation.id}`);
                       } else {
@@ -371,7 +367,11 @@ const ConsultationListPage: React.FC = () => {
                     <td className="px-6 py-4 whitespace-nowrap">
                       {formatDate(consultation.consultationDate)}
                     </td>
-                    <td className="px-6 py-4 whitespace-nowrap">{consultation.customerId}</td>
+                    <td className="px-6 py-4 whitespace-nowrap">{consultation.customer.name}</td>
+                    <td className="px-6 py-4 whitespace-nowrap">{consultation.customer.contact}</td>
+                    <td className="px-6 py-4 whitespace-nowrap">
+                      {consultation.customer.email || '-'}
+                    </td>
                     <td className="px-6 py-4 whitespace-nowrap">
                       {getTypeText(consultation.consultationType)}
                     </td>
@@ -383,9 +383,6 @@ const ConsultationListPage: React.FC = () => {
                       >
                         {getStatusText(consultation.status)}
                       </span>
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap truncate max-w-xs">
-                      {consultation.content || '-'}
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap">
                       {formatDate(consultation.createdAt)}

--- a/src/pages/contract/ContractList.tsx
+++ b/src/pages/contract/ContractList.tsx
@@ -133,6 +133,15 @@ const ContractList: React.FC = () => {
     <DashboardLayout>
       <div className="pb-5 border-b border-gray-200 sm:flex sm:items-center sm:justify-between">
         <h1 className="text-2xl font-bold text-gray-900">계약 관리</h1>
+        <div className="mt-3 sm:mt-0">
+          <Button
+            variant="primary"
+            onClick={() => navigate('/contracts/register')}
+            leftIcon={<Plus size={16} />}
+          >
+            계약 등록
+          </Button>
+        </div>
       </div>
 
       {/* 검색 및 필터 */}

--- a/src/pages/dashboard/Dashboard.tsx
+++ b/src/pages/dashboard/Dashboard.tsx
@@ -11,6 +11,7 @@ import { getDashboardStats, getRecentProperties, getChartData } from '../../api/
 import { Link } from 'react-router-dom';
 import { formatDate } from '../../utils/format';
 import { ChartData, RecentProperty } from '../../types/dashboard';
+import { PropertyTypeLabels } from '../../types/property';
 
 const Dashboard: React.FC = () => {
   const { showToast } = useToast();
@@ -197,7 +198,9 @@ const Dashboard: React.FC = () => {
                       recentProperties.map((property) => (
                         <tr key={property.id} className="hover:bg-gray-50">
                           <td className="px-6 py-4 whitespace-nowrap">
-                            <div className="text-sm text-gray-500">{property.propertyType}</div>
+                            <div className="text-sm text-gray-500">
+                              {PropertyTypeLabels[property.propertyType]}
+                            </div>
                           </td>
                           <td className="px-6 py-4 whitespace-nowrap">
                             <div className="text-sm text-gray-900">{property.location}</div>

--- a/src/pages/inquiryTemplate/InquiryTemplateManagement.tsx
+++ b/src/pages/inquiryTemplate/InquiryTemplateManagement.tsx
@@ -217,6 +217,7 @@ const InquiryTemplateManagement: React.FC = () => {
           onPreview={handleOpenPreviewModal}
           onDelete={handleOpenDeleteModal}
           isLoading={isLoading}
+          showToast={showToast}
         />
 
         {/* 페이지네이션 */}

--- a/src/types/consultation.ts
+++ b/src/types/consultation.ts
@@ -16,11 +16,11 @@ export const toApiConsultationType = (type: ConsultationType): 'PHONE' | 'VISIT'
 
 export type ConsultationStatus = 'reserved' | 'completed' | 'cancelled';
 
-export const toApiStatus = (status: ConsultationStatus): 'RESERVED' | 'COMPLETED' | 'CANCELED' => {
+export const toApiStatus = (status: ConsultationStatus): 'RESERVED' | 'COMPLETED' | 'CANCELLED' => {
   const map = {
     reserved: 'RESERVED',
     completed: 'COMPLETED',
-    cancelled: 'CANCELED',
+    cancelled: 'CANCELLED',
   } as const;
 
   return map[status];
@@ -50,11 +50,18 @@ export interface CreateConsultationResDto {
   deletedAt?: string;
 }
 
+export interface ConsultationCustomerResDto {
+  id: number;
+  name: string;
+  contact: string;
+  email: string;
+}
+
 // 상담 상세 정보 응답 DTO
 export interface ConsultationResDto {
   id: number;
   agentId: number;
-  customerId: number;
+  customer: ConsultationCustomerResDto;
   consultationType: ConsultationType;
   content?: string;
   consultationDate?: string;
@@ -101,7 +108,7 @@ export const fromApiStatus = (status: string): ConsultationStatus => {
   const map: Record<string, ConsultationStatus> = {
     RESERVED: 'reserved',
     COMPLETED: 'completed',
-    CANCELED: 'cancelled',
+    CANCELLED: 'cancelled',
   };
 
   return map[status] || 'reserved';

--- a/src/types/contract.ts
+++ b/src/types/contract.ts
@@ -14,7 +14,7 @@ export enum ContractType {
 export enum ContractStatus {
   IN_PROGRESS = 'IN_PROGRESS', // 계약 진행 중
   COMPLETED = 'COMPLETED', // 계약 완료
-  CANCELED = 'CANCELED', // 계약 취소
+  CANCELLED = 'CANCELLED', // 계약 취소
 }
 
 // 계약 유형 표시 텍스트
@@ -28,7 +28,7 @@ export const ContractTypeLabels: Record<ContractType, string> = {
 export const ContractStatusLabels: Record<ContractStatus, string> = {
   [ContractStatus.IN_PROGRESS]: '계약 진행 중',
   [ContractStatus.COMPLETED]: '계약 완료',
-  [ContractStatus.CANCELED]: '계약 취소',
+  [ContractStatus.CANCELLED]: '계약 취소',
 };
 
 // 계약 유형별 배경색 및 텍스트 색상
@@ -42,7 +42,7 @@ export const ContractTypeColors: Record<ContractType, { bg: string; text: string
 export const ContractStatusColors: Record<ContractStatus, { bg: string; text: string }> = {
   [ContractStatus.IN_PROGRESS]: { bg: 'bg-blue-100', text: 'text-blue-800' },
   [ContractStatus.COMPLETED]: { bg: 'bg-green-100', text: 'text-green-800' },
-  [ContractStatus.CANCELED]: { bg: 'bg-red-100', text: 'text-red-800' },
+  [ContractStatus.CANCELLED]: { bg: 'bg-red-100', text: 'text-red-800' },
 };
 
 // 계약 등록 요청 DTO

--- a/src/types/inquiryTemplate.ts
+++ b/src/types/inquiryTemplate.ts
@@ -4,6 +4,7 @@ export interface InquiryTemplate {
   name: string;
   description: string;
   isActive: boolean;
+  shareToken: string;
   questions: Question[];
   createdAt: string;
   updatedAt: string;


### PR DESCRIPTION
## 📌 PR 목적 및 내용
- 대시보드에서 매물 유형 한글로 표시하도록 처리.
- 계약 등록 페이지에서 매물 및 고객 선택 시 모달창을 띄워서 선택하도록 구현.
- 상담 관리 페이지에서 고객 ID 대신 고객 이름, 이메일, 연락처 보여주도록 변경.
- 상담 등록 페이지에서 고객 선택 시 모달창을 띄워서 선택하도록 구현.
- 템플릿 관리 페이지에서 각 템플릿 별 고객이 접근 가능한 문의 폼 접근 링크 복사 버튼 제공.

## ✏️ 변경 사항
- 대시보드에서 매물 유형 한글로 표시하도록 처리.
- 계약 등록 페이지에서 매물 및 고객 선택 시 모달창을 띄워서 선택하도록 구현.
- 상담 관리 페이지에서 고객 ID 대신 고객 이름, 이메일, 연락처 보여주도록 변경.
- 상담 등록 페이지에서 고객 선택 시 모달창을 띄워서 선택하도록 구현.
- 템플릿 관리 페이지에서 각 템플릿 별 고객이 접근 가능한 문의 폼 접근 링크 복사 버튼 제공.

## ✅ 체크리스트
- [ ] 코드가 정상적으로 동작하나요?
- [ ] 기존 코드와 충돌이 없나요?
- [ ] 테스트를 통과했나요?
- [ ] 문서 업데이트가 필요한가요?

## 🔗 관련 이슈 (선택사항)
- #43 
- #52 
- #55 
- #58 
- #60 
