### PR TITLE
youngseok, feat: SMS 목록 페이지에 영구 실패 추가+템플릿 정보 추가 + 고객 이름,이메일 존재하지 않는 경우 처리

### DIFF
--- a/src/components/customers/CustomerDetailModal.tsx
+++ b/src/components/customers/CustomerDetailModal.tsx
@@ -84,7 +84,7 @@ const CustomerDetailModal = ({ isOpen, onClose, customer, onUpdate }: CustomerDe
           <div className="space-y-4">
             <div>
               <h4 className="text-sm font-medium text-gray-500">이름</h4>
-              <p className="mt-1 text-gray-900">{customer.name}</p>
+              <p className="mt-1 text-gray-900">{customer.name || '선택 안 함'}</p>
             </div>
 
             <div>
@@ -94,7 +94,7 @@ const CustomerDetailModal = ({ isOpen, onClose, customer, onUpdate }: CustomerDe
 
             <div>
               <h4 className="text-sm font-medium text-gray-500">이메일</h4>
-              <p className="mt-1">{customer.email}</p>
+              <p className="mt-1">{customer.email || '선택 안 함'}</p>
             </div>
 
             <div>

--- a/src/components/customers/CustomerForm.tsx
+++ b/src/components/customers/CustomerForm.tsx
@@ -29,8 +29,10 @@ const customerSchema = z.object({
   name: z
     .string()
     .min(2, '이름은 2자 이상 50자 이하 여야 합니다.')
-    .max(50, '이름은 2자 이상 50자 이하 여야 합니다.'),
-  email: z.string().email('유효한 이메일 주소를 입력해주세요.'),
+    .max(50, '이름은 2자 이상 50자 이하 여야 합니다.')
+    .optional()
+    .or(z.literal('')),
+  email: z.string().email('유효한 이메일 주소를 입력해주세요.').optional().or(z.literal('')),
   contact: z
     .string()
     .regex(/^\d{2,3}-\d{3,4}-\d{4}$/, '유효한 전화번호 형식을 입력해주세요. (예: 010-1234-5678)'),
@@ -88,12 +90,18 @@ const CustomerForm = ({ initialData, onSubmit, onCancel }: CustomerFormProps) =>
   const onFormSubmit = (data: CustomerFormData) => {
     // 먼저 기본 데이터로 객체 생성
     const customerData: CreateCustomerReqDto = {
-      name: data.name,
-      email: data.email,
       contact: data.contact,
     };
 
     // 선택적 필드는 값이 있을 때만 추가
+    if (data.name) {
+      customerData.name = data.name;
+    }
+
+    if (data.email) {
+      customerData.email = data.email;
+    }
+
     if (data.ageGroup !== undefined) {
       customerData.ageGroup = Number(data.ageGroup);
     }
@@ -124,7 +132,6 @@ const CustomerForm = ({ initialData, onSubmit, onCancel }: CustomerFormProps) =>
                 placeholder="고객 이름"
                 error={errors.name?.message}
                 leftIcon={<User size={18} />}
-                required
               />
             )}
           />
@@ -141,7 +148,6 @@ const CustomerForm = ({ initialData, onSubmit, onCancel }: CustomerFormProps) =>
                   placeholder="example@example.com"
                   error={errors.email?.message}
                   leftIcon={<Mail size={18} />}
-                  required
                 />
               )}
             />

--- a/src/pages/customers/customer.tsx
+++ b/src/pages/customers/customer.tsx
@@ -288,7 +288,7 @@ const CustomersPage = () => {
       key: 'name',
       header: '이름',
       render: (customer: Customer) => (
-        <div className="font-medium text-gray-900">{customer.name}</div>
+        <div className="font-medium text-gray-900">{customer.name || '선택 안 함'}</div>
       ),
     },
     {
@@ -297,7 +297,7 @@ const CustomersPage = () => {
       render: (customer: Customer) => (
         <div>
           <div>{formatPhoneNumber(customer.contact)}</div>
-          <div className="text-gray-500 text-xs">{customer.email}</div>
+          <div className="text-gray-500 text-xs">{customer.email || '선택 안 함'}</div>
         </div>
       ),
     },

--- a/src/pages/sms/send.tsx
+++ b/src/pages/sms/send.tsx
@@ -488,45 +488,39 @@ const SmsSendPage = () => {
 
               {/* 템플릿 선택 */}
               <div>
-                <label htmlFor="template" className="block text-sm font-medium text-gray-700">
-                  템플릿 선택
-                </label>
-                <div className="flex space-x-2">
-                  <div>
-                    {isLoading ? (
-                      <div className="flex justify-center py-8">
-                        {/* 로딩 스피너 */}
-                        <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-blue-500"></div>
-                      </div>
-                    ) : templates.content.length === 0 ? (
-                      <div className="text-center py-8 text-gray-500">템플릿이 없습니다.</div>
-                    ) : (
-                      <Select
-                        id="template"
-                        value={selectedTemplateId?.toString() || ''}
-                        onChange={(value) =>
-                          setSelectedTemplateId(value ? Number.parseInt(value) : null)
-                        }
-                        options={[
-                          { value: '', label: '템플릿을 선택하세요' },
-                          ...templates.content.map((template) => ({
-                            value: template.id.toString(),
-                            label: template.title,
-                          })),
-                        ]}
-                        className="flex-1"
-                      />
-                    )}
+                <label className="block text-sm font-medium text-gray-700 mb-1">템플릿 선택</label>
+                {isLoading ? (
+                  <div className="flex justify-center py-4">
+                    <div className="animate-spin rounded-full h-6 w-6 border-t-2 border-b-2 border-blue-500"></div>
                   </div>
-                  <Button
-                    variant="outline"
-                    onClick={() => navigate('/sms/templates/create')}
-                    className="whitespace-nowrap"
-                  >
-                    <Plus size={16} className="mr-1" />
-                    템플릿 생성
-                  </Button>
-                </div>
+                ) : templates.content.length === 0 ? (
+                  <div className="text-sm text-gray-500">
+                    사용 가능한 템플릿이 없습니다.
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => navigate('/sms/templates/create')}
+                      className="ml-2"
+                    >
+                      <Plus size={16} className="mr-1" />
+                      템플릿 생성
+                    </Button>
+                  </div>
+                ) : (
+                  <Select
+                    value={selectedTemplateId?.toString() || ''}
+                    onChange={(value: string) => {
+                      setSelectedTemplateId(value ? Number(value) : null);
+                    }}
+                    options={[
+                      { value: '', label: '템플릿 선택' },
+                      ...templates.content.map((template) => ({
+                        value: template.id.toString(),
+                        label: template.title,
+                      })),
+                    ]}
+                  />
+                )}
               </div>
 
               {/* 메시지 유형 */}

--- a/src/pages/sms/sms.tsx
+++ b/src/pages/sms/sms.tsx
@@ -155,11 +155,22 @@ const SmsListPage = () => {
   };
 
   const formatContact = (contact: string) => {
-    if (!contact || contact.length !== 11) return '-';
-    const head = contact.substring(0, 3);
-    const body = contact.substring(3, 7);
-    const foot = contact.substring(7, 11);
-    return `${head}-${body}-${foot}`;
+    if (!contact) return '-';
+
+    // 하이픈이 포함된 경우 그대로 반환
+    if (contact.includes('-')) {
+      return contact;
+    }
+
+    // 11자리 숫자인 경우에만 포맷팅
+    if (contact.length === 11) {
+      const head = contact.substring(0, 3);
+      const body = contact.substring(3, 7);
+      const foot = contact.substring(7, 11);
+      return `${head}-${body}-${foot}`;
+    }
+
+    return contact;
   };
 
   // 테이블 컬럼 정의

--- a/src/pages/sms/sms.tsx
+++ b/src/pages/sms/sms.tsx
@@ -189,11 +189,24 @@ const SmsListPage = () => {
     {
       key: 'status',
       header: '발송 상태',
-      render: (sms: SendSmsResDto) => (
-        <Badge variant={sms.status === 'SUCCESS' ? 'success' : 'danger'} size="sm">
-          {sms.status === 'SUCCESS' ? '성공' : '실패'}
-        </Badge>
-      ),
+      render: (sms: SendSmsResDto) => {
+        let badgeVariant: 'success' | 'danger' | 'warning' = 'danger';
+        let statusText = '실패';
+
+        if (sms.status === 'SUCCESS') {
+          badgeVariant = 'success';
+          statusText = '성공';
+        } else if (sms.status === 'PERMANENT_FAIL') {
+          badgeVariant = 'warning';
+          statusText = '영구 실패';
+        }
+
+        return (
+          <Badge variant={badgeVariant} size="sm">
+            {statusText}
+          </Badge>
+        );
+      },
     },
     {
       key: 'actions',
@@ -218,6 +231,7 @@ const SmsListPage = () => {
     total: pagination.totalElements,
     success: smsList.filter((sms) => sms.status === 'SUCCESS').length,
     fail: smsList.filter((sms) => sms.status === 'FAIL').length,
+    permanentFail: smsList.filter((sms) => sms.status === 'PERMANENT_FAIL').length,
   };
 
   return (
@@ -236,23 +250,29 @@ const SmsListPage = () => {
       </div>
 
       {/* 통계 카드 */}
-      <div className="mt-6 grid grid-cols-1 gap-5 sm:grid-cols-3">
-        <Card className="bg-blue-50">
+      <div className="mt-6 grid grid-cols-1 gap-5 sm:grid-cols-4">
+        <Card className="bg-white-50">
           <div className="p-5">
-            <h3 className="text-lg font-medium text-gray-900">총 발송</h3>
+            <h3 className="text-lg font-medium text-gray-900">총 발송 건수</h3>
             <div className="mt-1 text-3xl font-semibold text-blue-600">{stats.total}</div>
           </div>
         </Card>
-        <Card className="bg-green-50">
+        <Card className="bg-white-50">
           <div className="p-5">
             <h3 className="text-lg font-medium text-gray-900">현재 페이지 발송 성공</h3>
             <div className="mt-1 text-3xl font-semibold text-green-600">{stats.success}</div>
           </div>
         </Card>
-        <Card className="bg-red-50">
+        <Card className="bg-white-50">
           <div className="p-5">
             <h3 className="text-lg font-medium text-gray-900">현재 페이지 발송 실패</h3>
             <div className="mt-1 text-3xl font-semibold text-red-600">{stats.fail}</div>
+          </div>
+        </Card>
+        <Card className="bg-white-50">
+          <div className="p-5">
+            <h3 className="text-lg font-medium text-gray-900">현재 페이지 영구 실패</h3>
+            <div className="mt-1 text-3xl font-semibold text-yellow-600">{stats.permanentFail}</div>
           </div>
         </Card>
       </div>
@@ -379,8 +399,21 @@ const SmsListPage = () => {
             <div>
               <h3 className="text-sm font-medium text-gray-500">발송 상태</h3>
               <div className="mt-1">
-                <Badge variant={selectedSms.status === 'SUCCESS' ? 'success' : 'danger'} size="sm">
-                  {selectedSms.status === 'SUCCESS' ? '성공' : '실패'}
+                <Badge
+                  variant={
+                    selectedSms.status === 'SUCCESS'
+                      ? 'success'
+                      : selectedSms.status === 'PERMANENT_FAIL'
+                        ? 'warning'
+                        : 'danger'
+                  }
+                  size="sm"
+                >
+                  {selectedSms.status === 'SUCCESS'
+                    ? '성공'
+                    : selectedSms.status === 'PERMANENT_FAIL'
+                      ? '영구 실패'
+                      : '실패'}
                 </Badge>
               </div>
             </div>

--- a/src/types/customer.ts
+++ b/src/types/customer.ts
@@ -15,8 +15,8 @@ export interface Customer {
 
 // 필요한 경우 하위 DTO 인터페이스 추가
 export interface CreateCustomerReqDto {
-  name: string;
-  email: string;
+  name?: string;
+  email?: string;
   contact: string;
   ageGroup?: number;
   gender?: 'M' | 'F' | undefined;

--- a/src/types/sms.ts
+++ b/src/types/sms.ts
@@ -8,7 +8,7 @@ export interface Sms {
   msg: string;
   msgType: 'SMS' | 'LMS' | 'MMS';
   title: string;
-  status: 'SUCCESS' | 'FAIL';
+  status: 'SUCCESS' | 'FAIL' | 'PERMANENT_FAIL';
   rdate: string;
   rtime: string;
   createdAt: string; // LocalDateTime ISO 포맷 문자열
@@ -45,7 +45,7 @@ export interface SendSmsResDto {
   msg: string; // 메시지 내용
   msgType: 'SMS' | 'LMS' | 'MMS'; // 메시지 유형
   title?: string; // 제목
-  status: 'SUCCESS' | 'FAIL';
+  status: 'SUCCESS' | 'FAIL' | 'PERMANENT_FAIL';
   rtime: string; // 예약 발송 시간
   rdate: string; // 예약 발송 일자
   createdAt: string;


### PR DESCRIPTION
## 📌 PR 목적 및 내용
- 문자 전송 시 템플릿 정보를 함께 저장하여, 문자 목록에서 템플릿 기반 필터링이 가능하도록 개선하였습니다.
- 문자 발송 실패 시, 3회 재전송에도 실패할 경우 '영구 실패' 상태로 전환되며, 이를 프론트엔드에서도 확인할 수 있도록 UI를 개선하였습니다.

## ✏️ 변경 사항
- 문자 전송 시 템플릿 정보를 문자 데이터에 저장
- 문자 목록에서 템플릿으로 필터링 기능 추가
- 중개업자가 생성한 템플릿이 없을 경우, 템플릿 선택 필드를 '템플릿 추가'로 대체
- 문자 발송 실패 시 3회 재시도 후 '영구 실패' 상태값으로 변경
- 문자 목록 및 상세 페이지에서 '영구 실패' 상태 노출
- 영구 실패 문자 개수 카운터 추가

## 📸 스크린샷 (선택사항)
- ![문자 목록 필터 및 영구 실패 상태 UI](https://github.com/user-attachments/assets/aee15a5f-df40-42ed-b596-fa1d)

## ✅ 체크리스트
- [x] 코드가 정상적으로 동작하나요?
- [x] 기존 코드와 충돌이 없나요?
- [x] 테스트를 통과했나요?
- [ ] 문서 업데이트가 필요한가요?

## 🔗 관련 이슈 (선택사항)
- #76
- #82 