### PR TITLE
youngseok, fix: 고객 목록에 삭제된 고객만 선택기능 추가  + 상세 페이지에서 입력값이 없는 필드에 선택 안함 …

### DIFF
--- a/src/api/customer.ts
+++ b/src/api/customer.ts
@@ -1,7 +1,7 @@
 import apiClient from './client';
 import type { ApiResponse } from '../types/api';
 import type {
-  CreateCustomerResDto,
+  CustomerResDto,
   CreateCustomerReqDto,
   CustomerListResDto,
   CustomerSearchFilter,
@@ -41,16 +41,13 @@ export const getMyCustomers = async (
 // 현재 로그인한 에이전트의 신규 고객 추가
 export const createMyCustomer = async (
   customerData: CreateCustomerReqDto
-): Promise<ApiResponse<CreateCustomerResDto>> => {
+): Promise<ApiResponse<CustomerResDto>> => {
   try {
-    const response = await apiClient.post<ApiResponse<CreateCustomerResDto>>(
-      '/customers',
-      customerData
-    );
+    const response = await apiClient.post<ApiResponse<CustomerResDto>>('/customers', customerData);
     return response.data;
   } catch (error) {
     if (axios.isAxiosError(error) && error.response) {
-      return error.response.data as ApiResponse<CreateCustomerResDto>;
+      return error.response.data as ApiResponse<CustomerResDto>;
     }
     return {
       success: false,
@@ -62,16 +59,16 @@ export const createMyCustomer = async (
 export const updateMyCustomer = async (
   id: number,
   customerData: CreateCustomerReqDto
-): Promise<ApiResponse<CreateCustomerReqDto>> => {
+): Promise<ApiResponse<CustomerResDto>> => {
   try {
-    const response = await apiClient.put<ApiResponse<CreateCustomerResDto>>(
+    const response = await apiClient.put<ApiResponse<CustomerResDto>>(
       `/customers/${id}`,
       customerData
     );
     return response.data;
   } catch (error) {
     if (axios.isAxiosError(error) && error.response) {
-      return error.response.data as ApiResponse<CreateCustomerResDto>;
+      return error.response.data as ApiResponse<CustomerResDto>;
     }
     return {
       success: false,
@@ -80,13 +77,13 @@ export const updateMyCustomer = async (
   }
 };
 
-export const deleteMyCustomer = async (id: number): Promise<ApiResponse<CreateCustomerResDto>> => {
+export const deleteMyCustomer = async (id: number): Promise<ApiResponse<CustomerResDto>> => {
   try {
-    const response = await apiClient.delete<ApiResponse<CreateCustomerResDto>>(`/customers/${id}`);
+    const response = await apiClient.delete<ApiResponse<CustomerResDto>>(`/customers/${id}`);
     return response.data;
   } catch (error) {
     if (axios.isAxiosError(error) && error.response) {
-      return error.response.data as ApiResponse<CreateCustomerResDto>;
+      return error.response.data as ApiResponse<CustomerResDto>;
     }
     return {
       success: false,
@@ -104,14 +101,12 @@ export const downloadExcelTemplate = async (): Promise<Blob> => {
 };
 
 // 엑셀 파일로 고객 정보 업로드
-export const uploadCustomersExcel = async (
-  file: File
-): Promise<ApiResponse<CreateCustomerResDto[]>> => {
+export const uploadCustomersExcel = async (file: File): Promise<ApiResponse<CustomerResDto[]>> => {
   try {
     const formData = new FormData();
     formData.append('file', file);
 
-    const response = await apiClient.post<ApiResponse<CreateCustomerResDto[]>>(
+    const response = await apiClient.post<ApiResponse<CustomerResDto[]>>(
       '/customers/upload',
       formData,
       {
@@ -123,7 +118,7 @@ export const uploadCustomersExcel = async (
     return response.data;
   } catch (error) {
     if (axios.isAxiosError(error) && error.response) {
-      return error.response.data as ApiResponse<CreateCustomerResDto[]>;
+      return error.response.data as ApiResponse<CustomerResDto[]>;
     }
     return {
       success: false,
@@ -237,15 +232,13 @@ export const getCustomerBuyContracts = async (
 };
 
 // 고객 복구
-export const restoreCustomer = async (id: number): Promise<ApiResponse<CreateCustomerResDto>> => {
+export const restoreCustomer = async (id: number): Promise<ApiResponse<CustomerResDto>> => {
   try {
-    const response = await apiClient.put<ApiResponse<CreateCustomerResDto>>(
-      `/customers/restore/${id}`
-    );
+    const response = await apiClient.put<ApiResponse<CustomerResDto>>(`/customers/restore/${id}`);
     return response.data;
   } catch (error) {
     if (axios.isAxiosError(error) && error.response) {
-      return error.response.data as ApiResponse<CreateCustomerResDto>;
+      return error.response.data as ApiResponse<CustomerResDto>;
     }
     return {
       success: false,

--- a/src/components/consultation/CustomerHistory.tsx
+++ b/src/components/consultation/CustomerHistory.tsx
@@ -20,7 +20,8 @@ import {
   getCustomerInquiries,
 } from '../../api/customer';
 import type { ApiResponse } from '../../types/api';
-import type { ConsultationListResDto, CustomerResDto } from '../../types/consultation';
+import type { ConsultationListResDto } from '../../types/consultation';
+import type { CustomerResDto } from '../../types/customer';
 import { ContractStatus, ContractType, type ContractListResDto } from '../../types/contract';
 import { CustomerType, type InquiryListResponse } from '../../types/inquiry';
 import { PaginationDto } from '../../types/pagination';

--- a/src/components/customers/ConsultationForm.tsx
+++ b/src/components/customers/ConsultationForm.tsx
@@ -7,12 +7,11 @@ import { Calendar, ArrowLeft, FileText, User, Edit, Phone, Plus, Search } from '
 import {
   ConsultationType,
   ConsultationStatus,
-  type CustomerResDto,
   type ConsultationReqDto,
   type UpdateConsultationReqDto,
   type NewCustomerDto,
 } from '../../types/consultation';
-import type { CreateCustomerResDto } from '../../types/customer';
+import type { CustomerResDto } from '../../types/customer';
 import {
   getConsultationById,
   createConsultation,
@@ -204,8 +203,8 @@ const ConsultationFormPage: React.FC = () => {
   };
 
   // 고객 선택 모달에서 고객 선택 시 호출되는 함수
-  const handleCustomerSelect = (customer: CreateCustomerResDto) => {
-    setSelectedCustomer(customer as CustomerResDto);
+  const handleCustomerSelect = (customer: CustomerResDto) => {
+    setSelectedCustomer(customer);
     setFormData((prev) => ({
       ...prev,
       customerId: customer.id,

--- a/src/components/customers/CustomerSelectionModal.tsx
+++ b/src/components/customers/CustomerSelectionModal.tsx
@@ -6,7 +6,7 @@ import { getMyCustomers } from '../../api/customer';
 import type {
   CustomerSearchFilter,
   CustomerListResDto,
-  CreateCustomerResDto,
+  CustomerResDto,
 } from '../../types/customer';
 import Button from '../ui/Button';
 import Input from '../ui/Input';
@@ -15,7 +15,7 @@ import { useToast } from '../../context/useToast';
 interface CustomerSelectionModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onSelectCustomer: (customer: CreateCustomerResDto) => void;
+  onSelectCustomer: (customer: CustomerResDto) => void;
   selectedCustomerId?: number | null;
 }
 

--- a/src/pages/consultation/ConsultationFormPage.tsx
+++ b/src/pages/consultation/ConsultationFormPage.tsx
@@ -8,10 +8,9 @@ import {
   ConsultationType,
   ConsultationStatus,
   type UpdateConsultationReqDto,
-  CustomerResDto,
   ConsultationReqDto,
 } from '../../types/consultation';
-import type { CreateCustomerResDto } from '../../types/customer';
+import type { CustomerResDto } from '../../types/customer';
 import {
   getConsultationById,
   createConsultation,
@@ -209,7 +208,7 @@ const ConsultationFormPage: React.FC = () => {
   };
 
   // 고객 선택 모달에서 고객 선택 시 호출되는 함수
-  const handleCustomerSelect = (customer: CreateCustomerResDto) => {
+  const handleCustomerSelect = (customer: CustomerResDto) => {
     setSelectedCustomer(customer);
     setFormData((prev) => ({
       ...prev,

--- a/src/pages/contract/ContractEdit.tsx
+++ b/src/pages/contract/ContractEdit.tsx
@@ -20,7 +20,7 @@ import {
 } from '../../types/contract';
 import { PropertyTypeLabels, type FindPropertyResDto } from '../../types/property';
 import PropertySelectionModal from '../../components/property/PropertySelectionModal';
-import type { CreateCustomerResDto } from '../../types/customer';
+import type { CustomerResDto } from '../../types/customer';
 import CustomerSelectionModal from '../../components/customers/CustomerSelectionModal';
 import { getObjectDiff } from '../../utils/objectUtil';
 import type { ContractResDto } from '../../types/contract';
@@ -96,7 +96,7 @@ const ContractEdit: React.FC = () => {
 
   // 폼 상태 관리
   const [selectedProperty, setSelectedProperty] = useState<FindPropertyResDto | null>(null);
-  const [selectedCustomer, setSelectedCustomer] = useState<CreateCustomerResDto | null>(null);
+  const [selectedCustomer, setSelectedCustomer] = useState<CustomerResDto | null>(null);
   const [contractType, setContractType] = useState<ContractType>(ContractType.SALE);
   const [contractStatus, setContractStatus] = useState<ContractStatus>(ContractStatus.IN_PROGRESS);
   const [salePrice, setSalePrice] = useState<string>('');
@@ -157,7 +157,7 @@ const ContractEdit: React.FC = () => {
   };
 
   const handleCustomerSelect = useCallback(
-    (customer: CreateCustomerResDto) => {
+    (customer: CustomerResDto) => {
       setSelectedCustomer(customer);
       setIsCustomerModalOpen(false);
       showToast('고객이 성공적으로 선택되었습니다.', 'success');

--- a/src/pages/contract/ContractRegistration.tsx
+++ b/src/pages/contract/ContractRegistration.tsx
@@ -20,7 +20,7 @@ import {
 } from '../../types/contract';
 import { PropertyType, PropertyTypeLabels, type FindPropertyResDto } from '../../types/property';
 import PropertySelectionModal from '../../components/property/PropertySelectionModal';
-import type { CreateCustomerResDto } from '../../types/customer';
+import type { CustomerResDto } from '../../types/customer';
 import CustomerSelectionModal from '../../components/customers/CustomerSelectionModal';
 import { getPropertyById } from '../../api/property';
 
@@ -83,7 +83,7 @@ const ContractRegistration: React.FC = () => {
 
   // 폼 상태 관리
   const [selectedProperty, setSelectedProperty] = useState<FindPropertyResDto | null>(null);
-  const [selectedCustomer, setSelectedCustomer] = useState<CreateCustomerResDto | null>(null);
+  const [selectedCustomer, setSelectedCustomer] = useState<CustomerResDto | null>(null);
   const [contractType, setContractType] = useState<ContractType>(ContractType.SALE);
   const [contractStatus, setContractStatus] = useState<ContractStatus>(ContractStatus.IN_PROGRESS);
   const [salePrice, setSalePrice] = useState<string>('');
@@ -136,7 +136,7 @@ const ContractRegistration: React.FC = () => {
   };
 
   // 고객 선택 모달에서 고객 선택 시 호출되는 함수
-  const handleCustomerSelect = (customer: CreateCustomerResDto) => {
+  const handleCustomerSelect = (customer: CustomerResDto) => {
     // 선택된 고객 정보를 바로 사용
     setSelectedCustomer(customer);
     showToast('고객이 성공적으로 선택되었습니다.', 'success');

--- a/src/pages/customers/CustomerDetailPage.tsx
+++ b/src/pages/customers/CustomerDetailPage.tsx
@@ -78,6 +78,11 @@ const CustomerDetailPage: React.FC = () => {
       try {
         const response = await getCustomerById(Number(id));
         if (response.success && response.data) {
+          if (response.data.deletedAt) {
+            showToast('삭제된 고객의 상세 정보는 볼 수 없습니다.', 'error');
+            navigate('/customers');
+            return;
+          }
           setCustomer(response.data);
         } else {
           showToast(response.error || '고객 정보를 불러오는데 실패했습니다.', 'error');
@@ -153,12 +158,12 @@ const CustomerDetailPage: React.FC = () => {
 
     try {
       const requestData: CreateCustomerReqDto = {
-        name: data.name || customer.name,
-        email: data.email || customer.email,
+        name: data.name === '' ? undefined : data.name || customer.name,
+        email: data.email === '' ? undefined : data.email || customer.email,
         contact: data.contact || customer.contact,
-        birthDate: data.birthDate || customer.birthDate,
-        gender: data.gender || customer.gender,
-        memo: data.memo || '',
+        birthDate: data.birthDate === '' ? undefined : data.birthDate || customer.birthDate,
+        gender: data.gender === undefined ? undefined : data.gender || customer.gender,
+        memo: data.memo === '' ? undefined : data.memo || customer.memo,
       };
 
       const response = await updateMyCustomer(customer.id, requestData);
@@ -171,7 +176,14 @@ const CustomerDetailPage: React.FC = () => {
         }
         setIsEditing(false);
       } else {
-        showToast(response.error || '고객 정보 수정에 실패했습니다.', 'error');
+        if (response.errors && response.errors.length > 0) {
+          // 각 에러 메시지를 토스트로 표시
+          response.errors.forEach((error) => {
+            showToast(error.message, 'error');
+          });
+        } else {
+          showToast(response.message || '고객 정보 수정에 실패했습니다.', 'error');
+        }
       }
     } catch (error) {
       console.error('고객 정보 수정 중 오류가 발생했습니다:', error);
@@ -264,7 +276,7 @@ const CustomerDetailPage: React.FC = () => {
                       </div>
                       <div>
                         <p className="text-sm font-medium text-gray-500">이름</p>
-                        <p className="text-gray-900">{customer.name}</p>
+                        <p className="text-gray-900">{customer.name || '선택 안 함'}</p>
                       </div>
                     </div>
 
@@ -284,7 +296,7 @@ const CustomerDetailPage: React.FC = () => {
                       </div>
                       <div>
                         <p className="text-sm font-medium text-gray-500">이메일</p>
-                        <p className="text-gray-900">{customer.email || '-'}</p>
+                        <p className="text-gray-900">{customer.email || '선택 안 함'}</p>
                       </div>
                     </div>
 
@@ -297,13 +309,13 @@ const CustomerDetailPage: React.FC = () => {
                         <p className="text-gray-900">
                           {customer.birthDate
                             ? new Date(customer.birthDate).toLocaleDateString()
-                            : '-'}{' '}
+                            : '선택 안 함'}{' '}
                           /{' '}
                           {customer.gender === 'M'
                             ? '남성'
                             : customer.gender === 'F'
                               ? '여성'
-                              : '-'}
+                              : '선택 안 함'}
                         </p>
                       </div>
                     </div>

--- a/src/pages/sms/send.tsx
+++ b/src/pages/sms/send.tsx
@@ -16,7 +16,7 @@ import { useToast } from '../../context/useToast';
 import { sendSms, getAllTemplates } from '../../api/smsApi';
 import { getMyCustomers } from '../../api/customer';
 import type { SendSmsReqDto, SmsTemplateListResDto } from '../../types/sms';
-import type { CreateCustomerResDto, CustomerListResDto } from '../../types/customer';
+import type { CustomerResDto, CustomerListResDto } from '../../types/customer';
 import { useAuth } from '../../context/useAuth';
 import Pagination from '../../components/ui/Pagination';
 
@@ -30,7 +30,7 @@ const SmsSendPage = () => {
   const [customers, setCustomers] = useState<CustomerListResDto>();
   const [isLoadingCustomers, setIsLoadingCustomers] = useState(false);
   // 단일 고객 선택에서 다중 고객 선택으로 변경
-  const [selectedCustomers, setSelectedCustomers] = useState<CreateCustomerResDto[]>([]);
+  const [selectedCustomers, setSelectedCustomers] = useState<CustomerResDto[]>([]);
   const [message, setMessage] = useState('');
   const [messageType, setMessageType] = useState<'SMS' | 'LMS' | 'MMS'>('SMS');
   const [isReservation, setIsReservation] = useState(false);
@@ -46,7 +46,7 @@ const SmsSendPage = () => {
     },
   });
   const [selectedTemplateId, setSelectedTemplateId] = useState<number | null>(null);
-  const [filteredCustomers, setFilteredCustomers] = useState<CreateCustomerResDto[]>([]);
+  const [filteredCustomers, setFilteredCustomers] = useState<CustomerResDto[]>([]);
   const { user } = useAuth();
 
   // 필터 상태로 페이지네이션 관리
@@ -196,7 +196,7 @@ const SmsSendPage = () => {
   };
 
   // 고객 선택 토글 (다중 선택)
-  const toggleCustomerSelection = (customer: CreateCustomerResDto) => {
+  const toggleCustomerSelection = (customer: CustomerResDto) => {
     setSelectedCustomers((prev) => {
       // 이미 선택된 고객인지 확인
       const isSelected = prev.some((c) => c.id === customer.id);

--- a/src/types/consultation.ts
+++ b/src/types/consultation.ts
@@ -1,4 +1,5 @@
 import { PaginationInfo } from './inquiry';
+import type { CustomerResDto } from './customer';
 
 export enum ConsultationType {
   PHONE = 'PHONE',
@@ -11,13 +12,6 @@ export enum ConsultationStatus {
   RESERVED = 'RESERVED',
   COMPLETED = 'COMPLETED',
   CANCELED = 'CANCELED',
-}
-
-export interface CustomerResDto {
-  id: number;
-  name: string;
-  contact: string;
-  email?: string;
 }
 
 // 문의 목록 응답 타입

--- a/src/types/contract.ts
+++ b/src/types/contract.ts
@@ -1,4 +1,4 @@
-import type { CreateCustomerResDto } from './customer';
+import type { CustomerResDto } from './customer';
 import type { FindPropertyResDto } from './property';
 import type { Agent } from './agent';
 import type { PaginationDto } from './pagination';
@@ -69,7 +69,7 @@ export interface ContractResDto {
   id: number;
   agent: Agent;
   property: FindPropertyResDto;
-  customer?: CreateCustomerResDto | null;
+  customer?: CustomerResDto | null;
   contractType: ContractType;
   status: ContractStatus;
   salePrice?: number;

--- a/src/types/customer.ts
+++ b/src/types/customer.ts
@@ -1,18 +1,16 @@
 import type { PaginationDto } from './pagination';
-import type { ConsultationResDto } from './consultation';
 
 export interface Customer {
   id: number;
-  name: string;
+  name?: string;
   email?: string;
   contact: string;
   birthDate?: string; // 선택적
   gender?: 'M' | 'F'; // 선택적
   memo?: string; // 선택적
   ageGroup?: number;
-  consultations?: ConsultationResDto[]; // 선택적
-  createdAt: string;
-  updatedAt: string | null;
+  createdAt?: string;
+  updatedAt?: string | null;
   deletedAt?: string | null;
 }
 
@@ -29,14 +27,14 @@ export interface CreateCustomerReqDto {
 
 export interface CreateCustomerResDto {
   id: number;
-  name: string;
-  email: string;
+  name?: string;
+  email?: string;
   contact: string;
-  birthDate: string;
+  birthDate?: string;
   gender?: 'M' | 'F' | undefined;
   memo?: string;
-  createdAt: string;
-  updatedAt: string;
+  createdAt?: string;
+  updatedAt?: string;
 }
 
 export interface CustomerListResDto {

--- a/src/types/customer.ts
+++ b/src/types/customer.ts
@@ -25,7 +25,7 @@ export interface CreateCustomerReqDto {
   ageGroup?: number;
 }
 
-export interface CreateCustomerResDto {
+export interface CustomerResDto {
   id: number;
   name?: string;
   email?: string;
@@ -35,10 +35,11 @@ export interface CreateCustomerResDto {
   memo?: string;
   createdAt?: string;
   updatedAt?: string;
+  deletedAt?: string;
 }
 
 export interface CustomerListResDto {
-  content: CreateCustomerResDto[];
+  content: CustomerResDto[];
   pagination: PaginationDto;
 }
 

--- a/src/types/property.ts
+++ b/src/types/property.ts
@@ -81,7 +81,7 @@ export interface FindPropertyResDto {
   jibunAddress: string;
   active: boolean;
   contractTypes: ContractType[];
-  customer: CreateCustomerResDto | null;
+  customer: CustomerResDto | null;
 }
 
 // 매물 목록 응답 LIST DTO

--- a/src/types/property.ts
+++ b/src/types/property.ts
@@ -1,4 +1,4 @@
-import type { CreateCustomerResDto } from './customer';
+import type { CustomerResDto } from './customer';
 import type { ContractResDto, ContractType } from './contract';
 import type { PaginationDto } from './pagination';
 
@@ -113,7 +113,7 @@ export interface PropertySearchFilter {
 export interface FindPropertyDetailResDto {
   id: number;
   propertyType: PropertyType;
-  customer: CreateCustomerResDto;
+  customer: CustomerResDto;
   memo?: string;
   detailAddress: string;
   roadAddress: string;


### PR DESCRIPTION
## 📌 PR 목적 및 내용
- 고객 상세 페이지에서 값이 없는 필드에 '선택 안함' 문구를 명시적으로 표시하여, 사용자가 데이터 입력 여부를 쉽게 파악할 수 있도록 UI/UX를 개선했습니다.
- 또한, 고객 목록 페이지에 '삭제된 고객만 보기' 필터 기능을 추가하였습니다.

## ✏️ 변경 사항
- 고객 상세 페이지에서 값이 입력되지 않은 필드에 '선택 안함' 표시가 나타나도록 변경
- 고객 목록 페이지에 '삭제된 고객만 보기' 체크박스(필터) 추가
- 관련 타입(customer.ts) 및 컴포넌트 로직 수정

## 📸 스크린샷 (선택사항)
- (UI 변경된 부분이 있다면 여기에 스크린샷을 첨부해주세요.)

## ✅ 체크리스트
- [x] 코드가 정상적으로 동작하나요?
- [x] 기존 코드와 충돌이 없나요?
- [x] 테스트를 통과했나요?
- [ ] 문서 업데이트가 필요한가요?

## 🔗 관련 이슈 (선택사항)
- #101
