### PR TITLE
seongeun, fix: 매물 등록 시 하나의 계약 정보를 함께 등록가능하도록 구현 + 지번 주소 누락 이슈 해결

### DIFF
--- a/src/api/consultation.ts
+++ b/src/api/consultation.ts
@@ -94,7 +94,6 @@ export const getConsultationList = async (params: {
         page: params.page ? params.page - 1 : 0, // 백엔드는 0부터 시작하는 페이지 인덱스 사용
       },
     });
-    console.log(response);
     return {
       success: true,
       data: response.data.data,

--- a/src/api/inquiryTemplate.ts
+++ b/src/api/inquiryTemplate.ts
@@ -12,7 +12,6 @@ export const getInquiryTemplates = async (
   filter: InquiryTemplateFilter
 ): Promise<ApiResponse<InquiryTemplateListResponse>> => {
   try {
-    console.log('filter', filter);
     const params = new URLSearchParams();
     if (filter.isActive !== undefined) params.append('isActive', filter.isActive.toString());
     if (filter.keyword !== undefined) params.append('keyword', filter.keyword);

--- a/src/api/property.ts
+++ b/src/api/property.ts
@@ -113,7 +113,6 @@ export const getPropertyById = async (
     const response = await apiClient.get<ApiResponse<FindPropertyDetailResDto>>(
       `/properties/${id}`
     );
-    console.log('Property detail response:', response.data);
     return response.data;
   } catch (error) {
     console.error('Error fetching property details:', error);

--- a/src/components/inquiry/QuestionField.tsx
+++ b/src/components/inquiry/QuestionField.tsx
@@ -255,7 +255,6 @@ const QuestionField: React.FC<QuestionFieldProps> = ({ question, control, error 
                   <RegionSelector
                     error={error?.message}
                     onChange={(regionData: RegionData | null) => {
-                      console.log(regionData);
                       onChange(regionData);
                     }}
                   />

--- a/src/components/inquiryTemplate/QuestionForm.tsx
+++ b/src/components/inquiryTemplate/QuestionForm.tsx
@@ -83,7 +83,6 @@ const QuestionForm: React.FC<QuestionFormProps> = ({ question, onSave, onCancel 
       isRequired,
       options: finalOptions,
     };
-    console.log('질문 데이터:', questionData);
 
     onSave(questionData);
   };

--- a/src/components/property/PropertyListItem.tsx
+++ b/src/components/property/PropertyListItem.tsx
@@ -14,7 +14,6 @@ interface PropertyListItemProps {
 }
 
 const PropertyListItem: React.FC<PropertyListItemProps> = ({ property }) => {
-  console.log('Property contractList:', property.contractTypes);
 
   return (
     <Link

--- a/src/components/region/RegionSelector.tsx
+++ b/src/components/region/RegionSelector.tsx
@@ -122,7 +122,6 @@ const RegionDropdown: FC<RegionDropdownProps> = ({ onChange = () => {}, initialV
         dong: selectedDongName,
         name: `${selectedProvinceName} ${selectedCityName} ${selectedDongName}`,
       };
-      console.log(regionData);
       onChange(regionData);
     } else {
       onChange(null);

--- a/src/components/ui/AddressInput.tsx
+++ b/src/components/ui/AddressInput.tsx
@@ -33,9 +33,10 @@ const AddressInput: React.FC<AddressProps> = ({ onAddressSelect }) => {
           const roadAddr = data.roadAddress;
           const zip = data.zonecode;
 
-          setJibunAddress(jibunAddr);
           if (data.autoJibunAddress) {
             setJibunAddress(data.autoJibunAddress);
+          } else {
+            setJibunAddress(jibunAddr);
           }
           setRoadAddress(roadAddr);
           setZipCode(zip);
@@ -48,9 +49,7 @@ const AddressInput: React.FC<AddressProps> = ({ onAddressSelect }) => {
           });
         },
       }).open();
-      console.log(jibunAddress);
     } catch (error) {
-      console.error('주소 검색 오류:', error);
       // 사용자에게 오류 메시지 표시
       showToast('주소 검색에 실패했습니다.', 'error');
     }

--- a/src/components/ui/AddressInput.tsx
+++ b/src/components/ui/AddressInput.tsx
@@ -28,12 +28,15 @@ const AddressInput: React.FC<AddressProps> = ({ onAddressSelect }) => {
   const handleAddressSearch = () => {
     try {
       new window.daum.Postcode({
-        oncomplete: (data: { jibunAddress: string; roadAddress: string; zonecode: string }) => {
+        oncomplete: (data: { jibunAddress: string; roadAddress: string; zonecode: string; autoJibunAddress: string }) => {
           const jibunAddr = data.jibunAddress;
           const roadAddr = data.roadAddress;
           const zip = data.zonecode;
 
           setJibunAddress(jibunAddr);
+          if (data.autoJibunAddress) {
+            setJibunAddress(data.autoJibunAddress);
+          }
           setRoadAddress(roadAddr);
           setZipCode(zip);
 
@@ -45,6 +48,7 @@ const AddressInput: React.FC<AddressProps> = ({ onAddressSelect }) => {
           });
         },
       }).open();
+      console.log(jibunAddress);
     } catch (error) {
       console.error('주소 검색 오류:', error);
       // 사용자에게 오류 메시지 표시

--- a/src/context/NotificationContext.tsx
+++ b/src/context/NotificationContext.tsx
@@ -68,7 +68,6 @@ export const NotificationProvider: React.FC<{ children: React.ReactNode }> = ({ 
     (event: MessageEvent) => {
       try {
         const data: NotificationEvent = JSON.parse(event.data);
-        console.log('SSE 알림 수신:', data);
 
         // 알림 객체 생성
         const newNotification: Notification = {

--- a/src/hooks/useSSE.ts
+++ b/src/hooks/useSSE.ts
@@ -36,9 +36,7 @@ const useSSE = ({
 
   // SSE 연결 함수
   const connect = useCallback(() => {
-    console.log('🔌 SSE 연결 시도:', url);
     if (eventSourceRef.current || isConnected) {
-      console.log('SSE 이미 연결됨. 재연결 생략');
       return;
     }
 

--- a/src/pages/contract/ContractDetail.tsx
+++ b/src/pages/contract/ContractDetail.tsx
@@ -3,7 +3,7 @@
 import type React from 'react';
 import { useState, useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { ArrowLeft, Edit2, Trash2, Calendar, FileText, User, Home } from 'react-feather';
+import { ArrowLeft, Edit2, Trash2, Calendar, FileText, User, Home, AlertCircle } from 'react-feather';
 import DashboardLayout from '../../components/layout/DashboardLayout';
 import Card from '../../components/ui/Card';
 import Button from '../../components/ui/Button';
@@ -128,6 +128,7 @@ const ContractDetail: React.FC = () => {
           >
             수정
           </Button>
+                     
           <Button
             variant="danger"
             onClick={handleDelete}
@@ -138,6 +139,15 @@ const ContractDetail: React.FC = () => {
           </Button>
         </div>
       </div>
+
+      {(contract.status === ContractStatus.COMPLETED || contract.status === ContractStatus.CANCELED) && (
+        <div className="flex justify-end mt-1">
+          <span className="text-xs text-gray-500 flex items-center">
+            <AlertCircle size={12} className="mr-1" />
+            완료 또는 취소된 계약은 수정할 수 없습니다.
+          </span>
+        </div>
+      )}
 
       <div className="mt-6">
         <Card>
@@ -199,8 +209,8 @@ const ContractDetail: React.FC = () => {
                       <Calendar className="h-5 w-5 text-gray-400 mr-2" />
                       <span className="text-gray-700">
                         계약 기간:
-                        {new Date(contract.startedAt).toLocaleDateString()} ~{' '}
-                        {new Date(contract.expiredAt).toLocaleDateString()}
+                        {contract.startedAt} ~{' '}
+                        {contract.expiredAt}
                       </span>
                     </div>
                   )}

--- a/src/pages/contract/ContractEdit.tsx
+++ b/src/pages/contract/ContractEdit.tsx
@@ -182,7 +182,6 @@ const ContractEdit: React.FC = () => {
         showToast('집주인은 계약 대상이 될 수 없습니다.');
         return;
       }
-      console.log('고객 선택');
       setSelectedTenant(customer);
       setIsCustomerModalOpen(false);
       showToast('고객이 성공적으로 선택되었습니다.', 'success');

--- a/src/pages/contract/ContractEdit.tsx
+++ b/src/pages/contract/ContractEdit.tsx
@@ -203,7 +203,7 @@ const ContractEdit: React.FC = () => {
   const showCompletedDate = contractStatus === ContractStatus.COMPLETED;
 
   // 계약 상태가 진행 중인 경우에만 계약 기간 필드 표시
-  const showContractPeriod = contractStatus !== ContractStatus.AVAILABLE;
+  const showContractPeriod = contractStatus !== ContractStatus.AVAILABLE && contractType !== ContractType.SALE;
 
   // 계약 유형 변경 시 가격 필드 초기화
   useEffect(() => {

--- a/src/pages/contract/ContractRegistration.tsx
+++ b/src/pages/contract/ContractRegistration.tsx
@@ -101,6 +101,12 @@ const ContractRegistration: React.FC = () => {
   // 계약 상태에 따른 고객 선택 필요 여부
   const isCustomerRequired = contractStatus !== ContractStatus.AVAILABLE;
 
+  // 매매가 아닐 때만 계약 기간 필드 표시
+  const showContractPeriod = contractStatus !== ContractStatus.AVAILABLE && contractType !== ContractType.SALE;
+
+  // 계약 상태가 완료인 경우 완료일 필드 표시
+  const showCompletedDate = contractStatus === ContractStatus.COMPLETED;
+
   // 계약 상태 변경 시 고객 정보 초기화
   useEffect(() => {
     if (contractStatus === ContractStatus.AVAILABLE) {
@@ -172,12 +178,6 @@ const ContractRegistration: React.FC = () => {
   const showSalePrice = contractType === ContractType.SALE;
   const showJeonsePrice = contractType === ContractType.JEONSE;
   const showMonthlyRent = contractType === ContractType.MONTHLY_RENT;
-
-  // 계약 상태가 완료인 경우 완료일 필드 표시
-  const showCompletedDate = contractStatus === ContractStatus.COMPLETED;
-
-  // 계약 상태가 진행 중인 경우에만 계약 기간 필드 표시
-  const showContractPeriod = contractStatus !== ContractStatus.AVAILABLE;
 
   // 계약 유형 변경 시 가격 필드 초기화
   useEffect(() => {

--- a/src/pages/contract/ContractRegistration.tsx
+++ b/src/pages/contract/ContractRegistration.tsx
@@ -70,6 +70,21 @@ const ContractStatusButton: React.FC<{
   </button>
 );
 
+interface ContractFormData {
+  propertyId: number | null;
+  customerId: number | null;
+  contractType: ContractType;
+  contractStatus: ContractStatus;
+  salePrice: string;
+  jeonsePrice: string;
+  monthlyRentDeposit: string;
+  monthlyRentFee: string;
+  startDate: string;
+  endDate: string;
+  completedDate: string;
+  memo: string;
+}
+
 const ContractRegistration: React.FC = () => {
   const navigate = useNavigate();
   const { showToast } = useToast();
@@ -82,37 +97,43 @@ const ContractRegistration: React.FC = () => {
   const queryParams = new URLSearchParams(location.search);
   const propertyIdParam = queryParams.get('propertyId');
 
-  // 폼 상태 관리
+  // 선택된 매물과 고객 정보
   const [selectedProperty, setSelectedProperty] = useState<FindPropertyResDto | null>(null);
-  const [selectedLandlord, setSelectedLandlord] = useState<CustomerResDto | null>(null); // 집주인
-  const [selectedTenant, setSelectedTenant] = useState<CustomerResDto | null>(null); // 계약자
-  const [contractType, setContractType] = useState<ContractType>(ContractType.SALE);
-  const [contractStatus, setContractStatus] = useState<ContractStatus>(ContractStatus.IN_PROGRESS);
-  const [salePrice, setSalePrice] = useState<string>('');
-  const [jeonsePrice, setJeonsePrice] = useState<string>('');
-  const [monthlyRentDeposit, setMonthlyRentDeposit] = useState<string>('');
-  const [monthlyRentFee, setMonthlyRentFee] = useState<string>('');
-  const [startDate, setStartDate] = useState<string>('');
-  const [endDate, setEndDate] = useState<string>('');
-  const [completedDate, setCompletedDate] = useState<string>('');
-  const [memo, setMemo] = useState<string>('');
-  // const [active, setActive] = useState<boolean>(true);
+  const [selectedLandlord, setSelectedLandlord] = useState<CustomerResDto | null>(null);
+  const [selectedTenant, setSelectedTenant] = useState<CustomerResDto | null>(null);
+
+  // 폼 데이터 상태
+  const [formData, setFormData] = useState<ContractFormData>({
+    propertyId: null,
+    customerId: null,
+    contractType: ContractType.SALE,
+    contractStatus: ContractStatus.IN_PROGRESS,
+    salePrice: '',
+    jeonsePrice: '',
+    monthlyRentDeposit: '',
+    monthlyRentFee: '',
+    startDate: '',
+    endDate: '',
+    completedDate: '',
+    memo: '',
+  });
 
   // 계약 상태에 따른 고객 선택 필요 여부
-  const isCustomerRequired = contractStatus !== ContractStatus.AVAILABLE;
+  const isCustomerRequired = formData.contractStatus !== ContractStatus.AVAILABLE;
 
   // 매매가 아닐 때만 계약 기간 필드 표시
-  const showContractPeriod = contractStatus !== ContractStatus.AVAILABLE && contractType !== ContractType.SALE;
+  const showContractPeriod = formData.contractStatus !== ContractStatus.AVAILABLE && formData.contractType !== ContractType.SALE;
 
   // 계약 상태가 완료인 경우 완료일 필드 표시
-  const showCompletedDate = contractStatus === ContractStatus.COMPLETED;
+  const showCompletedDate = formData.contractStatus === ContractStatus.COMPLETED;
 
   // 계약 상태 변경 시 고객 정보 초기화
   useEffect(() => {
-    if (contractStatus === ContractStatus.AVAILABLE) {
+    if (formData.contractStatus === ContractStatus.AVAILABLE) {
       setSelectedTenant(null);
+      setFormData(prev => ({ ...prev, customerId: null }));
     }
-  }, [contractStatus]);
+  }, [formData.contractStatus]);
 
   // propertyId가 URL 파라미터로 제공된 경우 해당 매물 정보 로드
   useEffect(() => {
@@ -122,12 +143,12 @@ const ContractRegistration: React.FC = () => {
       try {
         const response = await getPropertyById(Number(propertyIdParam));
         if (response.success && response.data) {
-          // setSelectedProperty(response.data);
           setSelectedProperty({
             ...response.data,
             propertyType: response.data.propertyType as PropertyType,
           } as unknown as FindPropertyResDto);
           setSelectedLandlord(response.data.customer || null);
+          setFormData(prev => ({ ...prev, propertyId: response.data?.id || null }));
         } else {
           showToast(response.error || '매물 정보를 불러오는데 실패했습니다.', 'error');
         }
@@ -140,11 +161,12 @@ const ContractRegistration: React.FC = () => {
   }, [propertyIdParam]);
 
   const handlePropertySelect = async (property: FindPropertyResDto) => {
-    // 선택된 매물 정보를 바로 사용
     setSelectedProperty(property);
     setSelectedLandlord(property.customer || null);
+    setFormData(prev => ({ ...prev, propertyId: property.id }));
     if (selectedTenant) {
       setSelectedTenant(null);
+      setFormData(prev => ({ ...prev, customerId: null }));
     }
     showToast('매물이 성공적으로 선택되었습니다.', 'success');
   };
@@ -155,8 +177,8 @@ const ContractRegistration: React.FC = () => {
       showToast('집주인은 계약 대상이 될 수 없습니다.');
       return;
     }
-    // 선택된 고객 정보를 바로 사용
     setSelectedTenant(customer);
+    setFormData(prev => ({ ...prev, customerId: customer.id }));
     showToast('고객이 성공적으로 선택되었습니다.', 'success');
   };
 
@@ -175,24 +197,24 @@ const ContractRegistration: React.FC = () => {
   };
 
   // 계약 유형에 따라 필요한 필드 표시 여부 결정
-  const showSalePrice = contractType === ContractType.SALE;
-  const showJeonsePrice = contractType === ContractType.JEONSE;
-  const showMonthlyRent = contractType === ContractType.MONTHLY_RENT;
+  const showSalePrice = formData.contractType === ContractType.SALE;
+  const showJeonsePrice = formData.contractType === ContractType.JEONSE;
+  const showMonthlyRent = formData.contractType === ContractType.MONTHLY_RENT;
 
   // 계약 유형 변경 시 가격 필드 초기화
   useEffect(() => {
-    // 계약 유형이 변경되면 모든 가격 필드 초기화
-    setSalePrice('');
-    setJeonsePrice('');
-    setMonthlyRentDeposit('');
-    setMonthlyRentFee('');
-  }, [contractType]);
+    setFormData(prev => ({
+      ...prev,
+      salePrice: '',
+      jeonsePrice: '',
+      monthlyRentDeposit: '',
+      monthlyRentFee: '',
+    }));
+  }, [formData.contractType]);
 
   // 만원 단위 가격을 원화 단위로 변환하는 함수
   const convertToWon = (manwonValue: string): number | null => {
     if (!manwonValue || manwonValue.trim() === '') return null;
-
-    // 변환: 만원 -> 원 (× 10000)
     return parseInt(manwonValue, 10) * 10000;
   };
 
@@ -201,34 +223,34 @@ const ContractRegistration: React.FC = () => {
     e.preventDefault();
 
     // 필수 필드 검증
-    if (!selectedProperty) {
+    if (!formData.propertyId) {
       showToast('매물을 선택해주세요.', 'error');
       return;
     }
 
     // 계약 상태에 따른 고객 필드 검증
-    if (isCustomerRequired && !selectedTenant) {
+    if (isCustomerRequired && !formData.customerId) {
       showToast('계약 중 또는 계약 완료 상태일 경우, 고객 선택은 필수입니다.', 'error');
       return;
     }
 
     // 계약 유형에 따른 가격 필드 검증
-    if (showSalePrice && !salePrice) {
+    if (showSalePrice && !formData.salePrice) {
       showToast('매매 계약의 경우 매매가는 필수입니다.', 'error');
       return;
     }
 
-    if (showJeonsePrice && !jeonsePrice) {
+    if (showJeonsePrice && !formData.jeonsePrice) {
       showToast('전세 계약의 경우 전세가는 필수입니다.', 'error');
       return;
     }
 
     if (showMonthlyRent) {
-      if (!monthlyRentDeposit) {
+      if (!formData.monthlyRentDeposit) {
         showToast('월세 계약의 경우 보증금은 필수입니다.', 'error');
         return;
       }
-      if (!monthlyRentFee) {
+      if (!formData.monthlyRentFee) {
         showToast('월세 계약의 경우 월세는 필수입니다.', 'error');
         return;
       }
@@ -236,17 +258,17 @@ const ContractRegistration: React.FC = () => {
 
     // 계약 상태에 따른 날짜 필드 검증
     if (showContractPeriod) {
-      if (!startDate) {
+      if (!formData.startDate) {
         showToast('계약 시작일은 필수입니다.', 'error');
         return;
       }
-      if (!endDate) {
+      if (!formData.endDate) {
         showToast('계약 종료일은 필수입니다.', 'error');
         return;
       }
 
       // 계약 기간 검증 (시작일이 종료일보다 늦으면 안 됨)
-      if (new Date(startDate) > new Date(endDate)) {
+      if (new Date(formData.startDate) > new Date(formData.endDate)) {
         showToast(
           '계약 종료일이 계약 시작일보다 빠를 수 없습니다. 날짜를 다시 확인해주세요.',
           'error'
@@ -256,7 +278,7 @@ const ContractRegistration: React.FC = () => {
     }
 
     // 계약 상태가 완료인데 완료일이 없는 경우
-    if (showCompletedDate && !completedDate) {
+    if (showCompletedDate && !formData.completedDate) {
       showToast('계약 완료 상태일 경우, 거래 완료일은 필수입니다.', 'error');
       return;
     }
@@ -265,46 +287,19 @@ const ContractRegistration: React.FC = () => {
 
     try {
       const contractData: ContractReqDto = {
-        propertyId: selectedProperty.id,
-        customerId: selectedTenant?.id ?? null,
-        contractType,
-        contractStatus,
-        memo: memo || null,
-        startedAt: startDate || null,
-        expiredAt: endDate || null,
-        salePrice: showSalePrice ? convertToWon(salePrice) : null,
-        jeonsePrice: showJeonsePrice ? convertToWon(jeonsePrice) : null,
-        monthlyRentDeposit: showMonthlyRent ? convertToWon(monthlyRentDeposit) : null,
-        monthlyRentFee: showMonthlyRent ? convertToWon(monthlyRentFee) : null,
-        completedAt: showCompletedDate ? completedDate : null,
-        // active,
+        propertyId: formData.propertyId,
+        customerId: formData.customerId,
+        contractType: formData.contractType,
+        contractStatus: formData.contractStatus,
+        memo: formData.memo || null,
+        startedAt: formData.startDate || null,
+        expiredAt: formData.endDate || null,
+        salePrice: showSalePrice ? convertToWon(formData.salePrice) : null,
+        jeonsePrice: showJeonsePrice ? convertToWon(formData.jeonsePrice) : null,
+        monthlyRentDeposit: showMonthlyRent ? convertToWon(formData.monthlyRentDeposit) : null,
+        monthlyRentFee: showMonthlyRent ? convertToWon(formData.monthlyRentFee) : null,
+        completedAt: showCompletedDate ? formData.completedDate : null,
       };
-
-      // 계약 상태에 따라 고객 ID 추가
-      if (isCustomerRequired && selectedTenant) {
-        contractData.customerId = selectedTenant.id;
-      }
-
-      // 계약 진행 중일 때만 계약 기간 추가
-      if (showContractPeriod) {
-        contractData.startedAt = startDate;
-        contractData.expiredAt = endDate;
-      }
-
-      // 계약 완료일 때만 완료일 추가
-      if (showCompletedDate) {
-        contractData.completedAt = completedDate;
-      }
-
-      // 계약 유형에 따라 가격 정보 추가
-      if (showSalePrice) {
-        contractData.salePrice = convertToWon(salePrice);
-      } else if (showJeonsePrice) {
-        contractData.jeonsePrice = convertToWon(jeonsePrice);
-      } else if (showMonthlyRent) {
-        contractData.monthlyRentDeposit = convertToWon(monthlyRentDeposit);
-        contractData.monthlyRentFee = convertToWon(monthlyRentFee);
-      }
 
       const response = await registerContract(contractData);
 
@@ -408,7 +403,7 @@ const ContractRegistration: React.FC = () => {
                     )}
                   </div>
 
-                  {contractStatus === ContractStatus.AVAILABLE ? (
+                  {formData.contractStatus === ContractStatus.AVAILABLE ? (
                     <div className="p-3 bg-gray-50 rounded-md text-left h-[88px] flex items-center">
                       <div className="w-10 h-10 rounded-full bg-yellow-100 flex items-center justify-center mr-3">
                         <AlertCircle size={20} className="text-yellow-500" />
@@ -472,8 +467,8 @@ const ContractRegistration: React.FC = () => {
                       <ContractTypeButton
                         key={type}
                         type={type}
-                        selected={contractType === type}
-                        onClick={() => setContractType(type)}
+                        selected={formData.contractType === type}
+                        onClick={() => setFormData(prev => ({ ...prev, contractType: type }))}
                       />
                     ))}
                   </div>
@@ -489,8 +484,8 @@ const ContractRegistration: React.FC = () => {
                       <ContractStatusButton
                         key={status}
                         status={status}
-                        selected={contractStatus === status}
-                        onClick={() => setContractStatus(status)}
+                        selected={formData.contractStatus === status}
+                        onClick={() => setFormData(prev => ({ ...prev, contractStatus: status }))}
                       />
                     ))}
                   </div>
@@ -504,17 +499,11 @@ const ContractRegistration: React.FC = () => {
                     매매가 <span className="text-red-500">*</span>
                   </label>
                   <PriceInput
-                    value={salePrice}
-                    onChange={setSalePrice}
+                    value={formData.salePrice}
+                    onChange={(value) => setFormData(prev => ({ ...prev, salePrice: value }))}
                     placeholder="매매가 입력 (만원 단위)"
                     required
                   />
-                  {/* <Input
-                    type="number"
-                    placeholder="매매가 입력"
-                    value={salePrice}
-                    onChange={(e) => setSalePrice(e.target.value)}
-                  /> */}
                 </div>
               )}
 
@@ -524,8 +513,8 @@ const ContractRegistration: React.FC = () => {
                     전세가 <span className="text-red-500">*</span>
                   </label>
                   <PriceInput
-                    value={jeonsePrice}
-                    onChange={setJeonsePrice}
+                    value={formData.jeonsePrice}
+                    onChange={(value) => setFormData(prev => ({ ...prev, jeonsePrice: value }))}
                     placeholder="전세가 입력 (만원 단위)"
                     required
                   />
@@ -539,14 +528,14 @@ const ContractRegistration: React.FC = () => {
                   </label>
                   <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                     <PriceInput
-                      value={monthlyRentDeposit}
-                      onChange={setMonthlyRentDeposit}
+                      value={formData.monthlyRentDeposit}
+                      onChange={(value) => setFormData(prev => ({ ...prev, monthlyRentDeposit: value }))}
                       placeholder="보증금 입력 (만원 단위)"
                       required
                     />
                     <PriceInput
-                      value={monthlyRentFee}
-                      onChange={setMonthlyRentFee}
+                      value={formData.monthlyRentFee}
+                      onChange={(value) => setFormData(prev => ({ ...prev, monthlyRentFee: value }))}
                       placeholder="월세 입력 (만원 단위)"
                       required
                     />
@@ -563,14 +552,14 @@ const ContractRegistration: React.FC = () => {
                   <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                     <Input
                       type="date"
-                      value={startDate}
-                      onChange={(e) => setStartDate(e.target.value)}
+                      value={formData.startDate}
+                      onChange={(e) => setFormData(prev => ({ ...prev, startDate: e.target.value }))}
                       leftIcon={<Calendar size={18} />}
                     />
                     <Input
                       type="date"
-                      value={endDate}
-                      onChange={(e) => setEndDate(e.target.value)}
+                      value={formData.endDate}
+                      onChange={(e) => setFormData(prev => ({ ...prev, endDate: e.target.value }))}
                       leftIcon={<Calendar size={18} />}
                     />
                   </div>
@@ -585,8 +574,8 @@ const ContractRegistration: React.FC = () => {
                   </label>
                   <Input
                     type="date"
-                    value={completedDate}
-                    onChange={(e) => setCompletedDate(e.target.value)}
+                    value={formData.completedDate}
+                    onChange={(e) => setFormData(prev => ({ ...prev, completedDate: e.target.value }))}
                     leftIcon={<CheckCircle size={18} />}
                     className="border-green-500 focus:ring-green-500"
                   />
@@ -603,8 +592,8 @@ const ContractRegistration: React.FC = () => {
                 </label>
                 <Textarea
                   placeholder="계약에 대한 추가 정보를 입력하세요."
-                  value={memo}
-                  onChange={(e) => setMemo(e.target.value)}
+                  value={formData.memo}
+                  onChange={(e) => setFormData(prev => ({ ...prev, memo: e.target.value }))}
                   className="min-h-[100px]"
                 />
               </div>

--- a/src/pages/inquiryTemplate/InquiryTemplateManagement.tsx
+++ b/src/pages/inquiryTemplate/InquiryTemplateManagement.tsx
@@ -109,7 +109,6 @@ const InquiryTemplateManagement: React.FC = () => {
   // 유형 필터 핸들러
   const handleTypeChange = (value: string) => {
     const templateType = value ? (value as unknown as InquiryTemplateType) : undefined;
-    console.log('templateType', templateType);
     setSelectedType(templateType);
     setFilter((prev) => ({
       ...prev,

--- a/src/pages/property/PropertyDetail.tsx
+++ b/src/pages/property/PropertyDetail.tsx
@@ -17,6 +17,7 @@ import {
   Compass,
   Square,
   Droplet,
+  Tag,
 } from 'react-feather';
 import { format } from 'date-fns';
 import DashboardLayout from '../../components/layout/DashboardLayout';
@@ -28,7 +29,7 @@ import { getPropertyById, deleteProperty } from '../../api/property';
 import {
   PropertyTypeLabels,
   PropertyDirectionLabels,
-  type FindPropertyDetailResDto,
+  FindPropertyDetailResDto,
 } from '../../types/property';
 import Modal from '../../components/ui/Modal';
 
@@ -265,6 +266,24 @@ const PropertyDetail: React.FC = () => {
               <div className="border-t border-gray-200 pt-4">
                 <h3 className="text-lg font-medium text-gray-900 mb-2 text-left">메모</h3>
                 <p className="text-gray-700 whitespace-pre-line">{property.memo}</p>
+              </div>
+            )}
+
+            {/* 태그 표시 */}
+            {property.tags && property.tags.length > 0 && (
+              <div className="border-t border-gray-200 pt-4">
+                <h3 className="text-lg font-medium text-gray-900 mb-2 text-left">태그</h3>
+                <div className="flex flex-wrap gap-2">
+                  {property.tags.map((tag) => (
+                    <span
+                      key={tag.tagId}
+                      className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800"
+                    >
+                      <Tag size={12} className="mr-1" />
+                      {tag.type}: {tag.value}
+                    </span>
+                  ))}
+                </div>
               </div>
             )}
           </div>

--- a/src/pages/property/PropertyEdit.tsx
+++ b/src/pages/property/PropertyEdit.tsx
@@ -10,7 +10,6 @@ import Button from '../../components/ui/Button';
 import Textarea from '../../components/ui/Textarea';
 import Input from '../../components/ui/Input';
 import AddressInput from '../../components/ui/AddressInput';
-import CustomerDropdown from '../../components/property/CustomerDropdown';
 import PropertyTypeSelector from '../../components/property/PropertyTypeSelector';
 import PropertyDirectionSelector from '../../components/property/PropertyDirectionSelector';
 import { useToast } from '../../context/useToast';
@@ -46,7 +45,6 @@ const PropertyEdit: React.FC = () => {
   const [jibunAddress, setJibunAddress] = useState('');
   const [detailAddress, setDetailAddress] = useState('');
   const [memo, setMemo] = useState('');
-  const [isCustomerSearchActive, setIsCustomerSearchActive] = useState(false);
   const [active, setActive] = useState(true);
 
   // 새로 추가된 필드들
@@ -161,19 +159,6 @@ const PropertyEdit: React.FC = () => {
 
     loadTags();
   }, []);
-
-  // 고객 선택 핸들러
-  const handleCustomerSelect = (customerId: number | null, customer?: Customer | null) => {
-    setSelectedCustomerId(customerId);
-    // 고객 객체가 전달되면 상태 업데이트
-    if (customer) {
-      setSelectedCustomer(customer);
-    } else {
-      setSelectedCustomer(null);
-    }
-    // 고객 선택 후 드롭다운 닫기
-    setIsCustomerSearchActive(false);
-  };
 
   // 주소 선택 핸들러
   const handleAddressSelect = (address: {

--- a/src/pages/property/PropertyRegistration.tsx
+++ b/src/pages/property/PropertyRegistration.tsx
@@ -17,8 +17,8 @@ import PriceInput from '../../components/contract/PriceInput';
 import { useToast } from '../../context/useToast';
 import { registerProperty } from '../../api/property';
 import type { PropertyType, PropertyDirection } from '../../types/property';
-import type { ContractReqDto } from '../../types/contract';
-import { ContractStatus, ContractType, ContractTypeLabels } from '../../types/contract';
+import type { BasicContractReqDto } from '../../types/contract';
+import { ContractType, ContractTypeLabels } from '../../types/contract';
 
 // 계약 유형 선택 버튼 컴포넌트
 const ContractTypeButton: React.FC<{
@@ -121,9 +121,8 @@ const PropertyRegistration: React.FC = () => {
     setIsSubmitting(true);
 
     try {
-      const contractData: ContractReqDto | undefined = contractType ? {
+      const contractData: BasicContractReqDto | undefined = contractType ? {
         contractType,
-        contractStatus: ContractStatus.AVAILABLE,
         salePrice: salePrice ? Number.parseInt(salePrice, 10) * 10000 : undefined,
         jeonsePrice: jeonsePrice ? Number.parseInt(jeonsePrice, 10) * 10000 : undefined,
         monthlyRentDeposit: monthlyRentDeposit ? Number.parseInt(monthlyRentDeposit, 10) * 10000 : undefined,

--- a/src/pages/property/PropertyRegistration.tsx
+++ b/src/pages/property/PropertyRegistration.tsx
@@ -11,7 +11,6 @@ import Textarea from '../../components/ui/Textarea';
 import Input from '../../components/ui/Input';
 import AddressInput from '../../components/ui/AddressInput';
 import PropertyTypeSelector from '../../components/property/PropertyTypeSelector';
-import CustomerDropdown from '../../components/property/CustomerDropdown';
 import PropertyDirectionSelector from '../../components/property/PropertyDirectionSelector';
 import PriceInput from '../../components/contract/PriceInput';
 import { useToast } from '../../context/useToast';

--- a/src/pages/property/PropertyRegistration.tsx
+++ b/src/pages/property/PropertyRegistration.tsx
@@ -45,33 +45,57 @@ const ContractTypeButton: React.FC<{
   </button>
 );
 
+interface PropertyFormData {
+  customerId: number | null;
+  propertyType: PropertyType | null;
+  roadAddress: string;
+  jibunAddress: string;
+  detailAddress: string;
+  memo: string;
+  active: boolean;
+  area: string;
+  floor: string;
+  allFloors: string;
+  direction: PropertyDirection | null;
+  bathroomCnt: string;
+  roomCnt: string;
+  contractType: ContractType | null;
+  salePrice: string;
+  jeonsePrice: string;
+  monthlyRentDeposit: string;
+  monthlyRentFee: string;
+}
+
 const PropertyRegistration: React.FC = () => {
   const navigate = useNavigate();
   const { showToast } = useToast();
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [selectedCustomerId, setSelectedCustomerId] = useState<number | null>(null);
-  const [propertyType, setPropertyType] = useState<PropertyType | null>(null);
-  const [roadAddress, setRoadAddress] = useState('');
-  const [jibunAddress, setJibunAddress] = useState('');
-  const [detailAddress, setDetailAddress] = useState('');
-  const [memo, setMemo] = useState('');
-  const [active, setActive] = useState(true);
-  const [area, setArea] = useState<string>('');
-  const [floor, setFloor] = useState<string>('');
-  const [allFloors, setAllFloors] = useState<string>('');
-  const [direction, setDirection] = useState<PropertyDirection | null>(null);
-  const [bathroomCnt, setBathroomCnt] = useState<string>('');
-  const [roomCnt, setRoomCnt] = useState<string>('');
-  const [contractType, setContractType] = useState<ContractType | null>(null);
-  const [salePrice, setSalePrice] = useState<string>('');
-  const [jeonsePrice, setJeonsePrice] = useState<string>('');
-  const [monthlyRentDeposit, setMonthlyRentDeposit] = useState<string>('');
-  const [monthlyRentFee, setMonthlyRentFee] = useState<string>('');
+  const [selectedCustomer, setSelectedCustomer] = useState<CustomerResDto | null>(null);
+  const [isCustomerModalOpen, setIsCustomerModalOpen] = useState(false);
   const [selectedTags, setSelectedTags] = useState<number[]>([]);
   const [availableTags, setAvailableTags] = useState<TagResDto[]>([]);
   const [isLoadingTags, setIsLoadingTags] = useState(false);
-  const [isCustomerModalOpen, setIsCustomerModalOpen] = useState(false);
-  const [selectedCustomer, setSelectedCustomer] = useState<CustomerResDto | null>(null);
+
+  const [formData, setFormData] = useState<PropertyFormData>({
+    customerId: null,
+    propertyType: null,
+    roadAddress: '',
+    jibunAddress: '',
+    detailAddress: '',
+    memo: '',
+    active: true,
+    area: '',
+    floor: '',
+    allFloors: '',
+    direction: null,
+    bathroomCnt: '',
+    roomCnt: '',
+    contractType: null,
+    salePrice: '',
+    jeonsePrice: '',
+    monthlyRentDeposit: '',
+    monthlyRentFee: '',
+  });
 
   // 주소 선택 핸들러
   const handleAddressSelect = (address: {
@@ -80,30 +104,33 @@ const PropertyRegistration: React.FC = () => {
     detailAddress: string;
     zipCode: string;
   }) => {
-    setRoadAddress(address.roadAddress);
-    setJibunAddress(address.jibunAddress);
-    setDetailAddress(address.detailAddress);
+    setFormData(prev => ({
+      ...prev,
+      roadAddress: address.roadAddress,
+      jibunAddress: address.jibunAddress,
+      detailAddress: address.detailAddress,
+    }));
   };
 
   // 숫자 입력 필드 핸들러 (정수만 허용)
   const handleIntegerInput = (
     e: React.ChangeEvent<HTMLInputElement>,
-    setter: React.Dispatch<React.SetStateAction<string>>
+    field: keyof PropertyFormData
   ) => {
     const value = e.target.value;
     if (value === '' || /^\d+$/.test(value)) {
-      setter(value);
+      setFormData(prev => ({ ...prev, [field]: value }));
     }
   };
 
   // 숫자 입력 필드 핸들러 (소수점 허용)
   const handleNumberInput = (
     e: React.ChangeEvent<HTMLInputElement>,
-    setter: React.Dispatch<React.SetStateAction<string>>
+    field: keyof PropertyFormData
   ) => {
     const value = e.target.value;
     if (value === '' || /^\d*\.?\d*$/.test(value)) {
-      setter(value);
+      setFormData(prev => ({ ...prev, [field]: value }));
     }
   };
 
@@ -112,16 +139,16 @@ const PropertyRegistration: React.FC = () => {
     e.preventDefault();
 
     // 필수 필드 검증
-    if (!selectedCustomerId) {
+    if (!formData.customerId) {
       showToast('고객을 선택해주세요.', 'error');
       return;
     }
 
-    if (!propertyType) {
+    if (!formData.propertyType) {
       showToast('매물 유형을 선택해주세요.', 'error');
       return;
     }
-    if (!roadAddress || !jibunAddress) {
+    if (!formData.roadAddress || !formData.jibunAddress) {
       showToast('주소를 입력해주세요.', 'error');
       return;
     }
@@ -129,28 +156,28 @@ const PropertyRegistration: React.FC = () => {
     setIsSubmitting(true);
 
     try {
-      const contractData: BasicContractReqDto | undefined = contractType ? {
-        contractType,
-        salePrice: salePrice ? Number.parseInt(salePrice, 10) * 10000 : undefined,
-        jeonsePrice: jeonsePrice ? Number.parseInt(jeonsePrice, 10) * 10000 : undefined,
-        monthlyRentDeposit: monthlyRentDeposit ? Number.parseInt(monthlyRentDeposit, 10) * 10000 : undefined,
-        monthlyRentFee: monthlyRentFee ? Number.parseInt(monthlyRentFee, 10) * 10000 : undefined,
+      const contractData: BasicContractReqDto | undefined = formData.contractType ? {
+        contractType: formData.contractType,
+        salePrice: formData.salePrice ? Number.parseInt(formData.salePrice, 10) * 10000 : undefined,
+        jeonsePrice: formData.jeonsePrice ? Number.parseInt(formData.jeonsePrice, 10) * 10000 : undefined,
+        monthlyRentDeposit: formData.monthlyRentDeposit ? Number.parseInt(formData.monthlyRentDeposit, 10) * 10000 : undefined,
+        monthlyRentFee: formData.monthlyRentFee ? Number.parseInt(formData.monthlyRentFee, 10) * 10000 : undefined,
       } : undefined;
 
       const propertyData = {
-        customerId: selectedCustomerId,
-        propertyType,
-        roadAddress,
-        jibunAddress,
-        detailAddress,
-        memo: memo || undefined,
-        active,
-        area: area ? Number.parseFloat(area) : undefined,
-        floor: floor ? Number.parseInt(floor, 10) : undefined,
-        allFloors: allFloors ? Number.parseInt(allFloors, 10) : undefined,
-        direction: direction || undefined,
-        bathroomCnt: bathroomCnt ? Number.parseInt(bathroomCnt, 10) : undefined,
-        roomCnt: roomCnt ? Number.parseInt(roomCnt, 10) : undefined,
+        customerId: formData.customerId,
+        propertyType: formData.propertyType,
+        roadAddress: formData.roadAddress,
+        jibunAddress: formData.jibunAddress,
+        detailAddress: formData.detailAddress,
+        memo: formData.memo || undefined,
+        active: formData.active,
+        area: formData.area ? Number.parseFloat(formData.area) : undefined,
+        floor: formData.floor ? Number.parseInt(formData.floor, 10) : undefined,
+        allFloors: formData.allFloors ? Number.parseInt(formData.allFloors, 10) : undefined,
+        direction: formData.direction || undefined,
+        bathroomCnt: formData.bathroomCnt ? Number.parseInt(formData.bathroomCnt, 10) : undefined,
+        roomCnt: formData.roomCnt ? Number.parseInt(formData.roomCnt, 10) : undefined,
         contract: contractData,
         tagIds: selectedTags,
       };
@@ -242,7 +269,10 @@ const PropertyRegistration: React.FC = () => {
               </div>
 
               {/* 매물 유형 선택 */}
-              <PropertyTypeSelector selectedType={propertyType} onChange={setPropertyType} />
+              <PropertyTypeSelector 
+                selectedType={formData.propertyType} 
+                onChange={(type) => setFormData(prev => ({ ...prev, propertyType: type }))} 
+              />
 
               {/* 주소 입력 */}
               <AddressInput onAddressSelect={handleAddressSelect} />
@@ -253,8 +283,8 @@ const PropertyRegistration: React.FC = () => {
                   id="active"
                   type="checkbox"
                   className="h-4 w-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500"
-                  checked={active}
-                  onChange={(e) => setActive(e.target.checked)}
+                  checked={formData.active}
+                  onChange={(e) => setFormData(prev => ({ ...prev, active: e.target.checked }))}
                 />
                 <label htmlFor="active" className="ml-2 block text-sm text-gray-700">
                   매물 활성화 (체크 해제 시 비활성화)
@@ -267,52 +297,55 @@ const PropertyRegistration: React.FC = () => {
                 <Input
                   label="면적 (평)"
                   placeholder="예: 24.5"
-                  value={area}
-                  onChange={(e) => handleNumberInput(e, setArea)}
+                  value={formData.area}
+                  onChange={(e) => handleNumberInput(e, 'area')}
                 />
 
                 {/* 층수 */}
                 <Input
                   label="층수"
                   placeholder="예: 3"
-                  value={floor}
-                  onChange={(e) => handleIntegerInput(e, setFloor)}
+                  value={formData.floor}
+                  onChange={(e) => handleIntegerInput(e, 'floor')}
                 />
 
                 {/* 총 층수 */}
                 <Input
                   label="총 층수"
                   placeholder="예: 15"
-                  value={allFloors}
-                  onChange={(e) => handleIntegerInput(e, setAllFloors)}
+                  value={formData.allFloors}
+                  onChange={(e) => handleIntegerInput(e, 'allFloors')}
                 />
 
                 {/* 방 개수 */}
                 <Input
                   label="방 개수"
                   placeholder="예: 2"
-                  value={roomCnt}
-                  onChange={(e) => handleIntegerInput(e, setRoomCnt)}
+                  value={formData.roomCnt}
+                  onChange={(e) => handleIntegerInput(e, 'roomCnt')}
                 />
 
                 {/* 욕실 개수 */}
                 <Input
                   label="욕실 개수"
                   placeholder="예: 1"
-                  value={bathroomCnt}
-                  onChange={(e) => handleIntegerInput(e, setBathroomCnt)}
+                  value={formData.bathroomCnt}
+                  onChange={(e) => handleIntegerInput(e, 'bathroomCnt')}
                 />
               </div>
 
               {/* 방향 선택 */}
-              <PropertyDirectionSelector selectedDirection={direction} onChange={setDirection} />
+              <PropertyDirectionSelector 
+                selectedDirection={formData.direction} 
+                onChange={(direction) => setFormData(prev => ({ ...prev, direction }))} 
+              />
 
               {/* 메모 */}
               <Textarea
                 label="메모 (선택사항)"
                 placeholder="매물에 대한 추가 정보를 입력하세요."
-                value={memo}
-                onChange={(e) => setMemo(e.target.value)}
+                value={formData.memo}
+                onChange={(e) => setFormData(prev => ({ ...prev, memo: e.target.value }))}
                 className="min-h-[100px]"
               />
 
@@ -363,57 +396,57 @@ const PropertyRegistration: React.FC = () => {
                         <ContractTypeButton
                           key={type}
                           type={type}
-                          selected={contractType === type}
-                          onClick={() => setContractType(type)}
+                          selected={formData.contractType === type}
+                          onClick={() => setFormData(prev => ({ ...prev, contractType: type }))}
                         />
                       ))}
                     </div>
                   </div>
 
                   {/* 가격 정보 */}
-                  {contractType === 'SALE' && (
+                  {formData.contractType === 'SALE' && (
                     <div>
                       <label className="block text-sm font-medium text-gray-700 mb-1 text-left">
                         매매가 <span className="text-red-500">*</span>
                       </label>
                       <PriceInput
-                        value={salePrice}
-                        onChange={setSalePrice}
+                        value={formData.salePrice}
+                        onChange={(value) => setFormData(prev => ({ ...prev, salePrice: value }))}
                         placeholder="매매가 입력 (만원 단위)"
                         required
                       />
                     </div>
                   )}
 
-                  {contractType === 'JEONSE' && (
+                  {formData.contractType === 'JEONSE' && (
                     <div>
                       <label className="block text-sm font-medium text-gray-700 mb-1 text-left">
                         전세가 <span className="text-red-500">*</span>
                       </label>
                       <PriceInput
-                        value={jeonsePrice}
-                        onChange={setJeonsePrice}
+                        value={formData.jeonsePrice}
+                        onChange={(value) => setFormData(prev => ({ ...prev, jeonsePrice: value }))}
                         placeholder="전세가 입력 (만원 단위)"
                         required
                       />
                     </div>
                   )}
 
-                  {contractType === 'MONTHLY_RENT' && (
+                  {formData.contractType === 'MONTHLY_RENT' && (
                     <div>
                       <label className="block text-sm font-medium text-gray-700 mb-1 text-left">
                         보증금/월세 <span className="text-red-500">*</span>
                       </label>
                       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                         <PriceInput
-                          value={monthlyRentDeposit}
-                          onChange={setMonthlyRentDeposit}
+                          value={formData.monthlyRentDeposit}
+                          onChange={(value) => setFormData(prev => ({ ...prev, monthlyRentDeposit: value }))}
                           placeholder="보증금 입력 (만원 단위)"
                           required
                         />
                         <PriceInput
-                          value={monthlyRentFee}
-                          onChange={setMonthlyRentFee}
+                          value={formData.monthlyRentFee}
+                          onChange={(value) => setFormData(prev => ({ ...prev, monthlyRentFee: value }))}
                           placeholder="월세 입력 (만원 단위)"
                           required
                         />
@@ -452,7 +485,7 @@ const PropertyRegistration: React.FC = () => {
         onClose={() => setIsCustomerModalOpen(false)}
         onSelectCustomer={(customer) => {
           setSelectedCustomer(customer);
-          setSelectedCustomerId(customer.id);
+          setFormData(prev => ({ ...prev, customerId: customer.id }));
           setIsCustomerModalOpen(false);
         }}
       />

--- a/src/types/contract.ts
+++ b/src/types/contract.ts
@@ -48,6 +48,15 @@ export const ContractStatusColors: Record<ContractStatus, { bg: string; text: st
   [ContractStatus.CANCELED]: { bg: 'bg-red-100', text: 'text-red-800' },
 };
 
+// 매물 등록시 기본 계약 정보 등록 요청 DTO
+export interface BasicContractReqDto {
+  contractType: ContractType;
+  salePrice?: number | null;
+  jeonsePrice?: number | null;
+  monthlyRentDeposit?: number | null;
+  monthlyRentFee?: number | null;
+}
+
 // 계약 등록 요청 DTO
 export interface ContractReqDto {
   propertyId?: number;

--- a/src/types/property.ts
+++ b/src/types/property.ts
@@ -130,5 +130,6 @@ export interface FindPropertyDetailResDto {
   direction?: PropertyDirection; // 방향
   bathroomCnt?: number; // 욕실 개수
   roomCnt?: number; // 방 개수
+  tagIds?: number[];
 }
 

--- a/src/types/property.ts
+++ b/src/types/property.ts
@@ -1,5 +1,5 @@
 import type { CustomerResDto } from './customer';
-import type { ContractResDto, ContractReqDto, ContractType, BasicContractReqDto } from './contract';
+import type { ContractResDto, ContractType, BasicContractReqDto } from './contract';
 import type { PaginationDto } from './pagination';
 
 // 매물 유형 enum

--- a/src/types/property.ts
+++ b/src/types/property.ts
@@ -1,5 +1,5 @@
 import type { CustomerResDto } from './customer';
-import type { ContractResDto, ContractReqDto, ContractType } from './contract';
+import type { ContractResDto, ContractReqDto, ContractType, BasicContractReqDto } from './contract';
 import type { PaginationDto } from './pagination';
 
 // 매물 유형 enum
@@ -70,7 +70,7 @@ export interface PropertyRegistrationDTO {
   bathroomCnt?: number; // 욕실 개수
   roomCnt?: number; // 방 개수
   active?: boolean; // 계약 가능 여부
-  contract?: ContractReqDto;
+  contract?: BasicContractReqDto;
   tagIds?: number[];
 }
 

--- a/src/types/property.ts
+++ b/src/types/property.ts
@@ -1,6 +1,7 @@
 import type { CustomerResDto } from './customer';
 import type { ContractResDto, ContractType, BasicContractReqDto } from './contract';
 import type { PaginationDto } from './pagination';
+import type { TagResDto } from './tag';
 
 // 매물 유형 enum
 export enum PropertyType {
@@ -130,6 +131,6 @@ export interface FindPropertyDetailResDto {
   direction?: PropertyDirection; // 방향
   bathroomCnt?: number; // 욕실 개수
   roomCnt?: number; // 방 개수
-  tagIds?: number[];
+  tags?: TagResDto[];
 }
 


### PR DESCRIPTION
## 📌 PR 목적 및 내용
- 매물 등록시 하나의 계약 정보를 함께 등록가능하도록 구현
- 지번 주소 여러개인 주소 선택시 자동으로 지번 주소 설정되도록 구현
- console.log 삭제
- 매물 등록, 수정 시 고객 선택 드롭다운 -> 모달로 변경
- 계약, 매물 페이지에서 여러 useState 호출 -> formData 로 통합 리팩토링

## ✅ 체크리스트
- [ ] 코드가 정상적으로 동작하나요?
- [ ] 기존 코드와 충돌이 없나요?
- [ ] 테스트를 통과했나요?
- [ ] 문서 업데이트가 필요한가요?

## 🔗 관련 이슈 (선택사항)
- #117 
- #125 
