### PR TITLE
hyunho, feat: 크롤링 매물 조회 시 초기값 표시 #143

### DIFF
--- a/src/pages/crawling-property/CrawlingPropertyPage.tsx
+++ b/src/pages/crawling-property/CrawlingPropertyPage.tsx
@@ -42,8 +42,8 @@ const propertyTypeKoreanMap = {
 export const CrawlingPropertyPage = () => {
   const { showToast } = useToast();
   const [searchParams, setSearchParams] = useState({
-    province: '',
-    city: '',
+    province: '서울시', // 초기 화면에서 로딩이 너무 길기 때문에 전체 조회를 피하기 위해 초기값 설정
+    city: '마포구',
     dong: ''
   });
 
@@ -256,8 +256,8 @@ export const CrawlingPropertyPage = () => {
       const params: CrawlingPropertySearchParams = {
         propertyType: selectedPropertyType as CrawlingPropertyType || undefined,
         transactionType: selectedContractType as CrawlingTransactionType || undefined,
-        province: searchParams.province || "서울시", // 초기 화면에서 로딩이 너무 길기 때문에 전체 조회를 피하기 위해 초기값 설정
-        city: searchParams.city || "마포구",
+        province: searchParams.province || undefined,
+        city: searchParams.city || undefined,
         dong: searchParams.dong || undefined,
         page: page,
         size: pagination.size,


### PR DESCRIPTION
## 📌 PR 목적 및 내용
- 크롤링 매물 조회 페이지 진입 시 전체 조회를 피하기 위해 초기 검색 조건을 서울시/마포구로 설정하였음
- 하지만 검색 조건 입력칸에는 해당 정보를 표시하지 않아 고객에게 혼동을 야기할 수 있음
- 해당 정보가 페이지 진입 시 표시되도록 수정 
![image](https://github.com/user-attachments/assets/81aabfb0-0e8c-46b7-a6b0-14163be6de93)


## ✏️ 변경 사항

## 📸 스크린샷 (선택사항)

## ✅ 체크리스트
- [ ] 코드가 정상적으로 동작하나요?
- [ ] 기존 코드와 충돌이 없나요?
- [ ] 테스트를 통과했나요?
- [ ] 문서 업데이트가 필요한가요?

## 🔗 관련 이슈 (선택사항)
- #143 