### PR TITLE
seongeun, fix: 매물 등록시 태그 중에서 방 개수 선택 중복 불가하도록 수정 #122

### DIFF
--- a/src/pages/property/PropertyRegistration.tsx
+++ b/src/pages/property/PropertyRegistration.tsx
@@ -346,11 +346,31 @@ const PropertyRegistration: React.FC = () => {
                       key={tag.tagId}
                       type="button"
                       onClick={() => {
-                        setSelectedTags((prev) =>
-                          prev.includes(tag.tagId)
-                            ? prev.filter((id) => id !== tag.tagId)
-                            : [...prev, tag.tagId]
-                        );
+                        // 방 개수 태그인 경우
+                        if (tag.type === '방 개수') {
+                          // 이미 선택된 방 개수 태그가 있는지 확인
+                          const existingRoomTag = availableTags.find(
+                            (t) => t.type === '방 개수' && selectedTags.includes(t.tagId)
+                          );
+
+                          if (existingRoomTag) {
+                            // 이미 선택된 방 개수 태그가 있다면, 해당 태그를 제거하고 새로운 태그를 추가
+                            setSelectedTags((prev) => [
+                              ...prev.filter((id) => id !== existingRoomTag.tagId),
+                              tag.tagId,
+                            ]);
+                          } else {
+                            // 선택된 방 개수 태그가 없다면, 새로운 태그 추가
+                            setSelectedTags((prev) => [...prev, tag.tagId]);
+                          }
+                        } else {
+                          // 방 개수가 아닌 다른 태그들은 자유롭게 선택 가능
+                          setSelectedTags((prev) =>
+                            prev.includes(tag.tagId)
+                              ? prev.filter((id) => id !== tag.tagId)
+                              : [...prev, tag.tagId]
+                          );
+                        }
                       }}
                       className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
                         selectedTags.includes(tag.tagId)


### PR DESCRIPTION
## 📌 PR 목적 및 내용
- 매물 등록시 태그 설정할 때, 방 개수는 중복 선택 불가하도록 수정

## ✅ 체크리스트
- [ ] 코드가 정상적으로 동작하나요?
- [ ] 기존 코드와 충돌이 없나요?
- [ ] 테스트를 통과했나요?
- [ ] 문서 업데이트가 필요한가요?

## 🔗 관련 이슈 (선택사항)
- #122
