### PR TITLE
fix: 공개 매물 검색 시 필터 초기화 후 검색했는데 서울시 마포구 지정되는 버그 해결 #177

### DIFF
--- a/src/pages/crawling-property/CrawlingPropertyPage.tsx
+++ b/src/pages/crawling-property/CrawlingPropertyPage.tsx
@@ -187,8 +187,8 @@ export const CrawlingPropertyPage = () => {
         province:
           selectedRegion.doName && regionNameMap[selectedRegion.doName]
             ? regionNameMap[selectedRegion.doName]
-            : selectedRegion.doName || '서울',
-        city: selectedRegion.sigunguName || '마포구',
+            : selectedRegion.doName || '',
+        city: selectedRegion.sigunguName || '',
         dong: selectedRegion.dongName || '',
         page: 1,
         size: pagination.size,


### PR DESCRIPTION
## 📌 PR 목적 및 내용
- 공개 매물 검색 시 필터 초기화 후 검색했는데 서울시 마포구 지정되는 버그 해결

## ✏️ 변경 사항
- 커밋 참고

## 📸 스크린샷 (선택사항)
- UI 변경이나 기능 추가 시 스크린샷을 첨부해주세요.

## ✅ 체크리스트
- [ ] 코드가 정상적으로 동작하나요?
- [ ] 기존 코드와 충돌이 없나요?
- [ ] 테스트를 통과했나요?
- [ ] 문서 업데이트가 필요한가요?

## 🔗 관련 이슈 (선택사항)
- #177
